### PR TITLE
Truncanted svd based on cumulative energy

### DIFF
--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -31,10 +31,13 @@ class CDMD(DMDBase):
 	  each row contains an element equal to 1 and all the other
 	  elements are null.
 
-	:param int svd_rank: rank truncation in SVD. If 0, the method computes the
-		optimal rank and uses it for truncation; if positive number, the method
-		uses the argument for the truncation; if -1, the method does not
-		compute truncation.
+	:param svd_rank: the rank for the truncation; If 0, the method computes the
+		optimal rank and uses it for truncation; if positive interger, the
+		method uses the argument for the truncation; if float between 0 and 1,
+		the rank is the number of the biggest singular values that are needed
+		to reach the 'energy' specified by `svd_rank`; if -1, the method does
+		not compute truncation.
+	:type svd_rank: int or float
 	:param int tlsq_rank: rank truncation computing Total Least Square. Default
 		is 0, that means no truncation.
 	:param compression_matrix: the matrix that pre-multiplies the snapshots

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -8,10 +8,13 @@ class DMD(DMDBase):
 	"""
 	Dynamic Mode Decomposition
 
-	:param int svd_rank: rank truncation in SVD. If 0, the method computes the
-		optimal rank and uses it for truncation; if positive number, the method
-		uses the argument for the truncation; if -1, the method does not
-		compute truncation.
+	:param svd_rank: the rank for the truncation; If 0, the method computes the
+		optimal rank and uses it for truncation; if positive interger, the
+		method uses the argument for the truncation; if float between 0 and 1,
+		the rank is the number of the biggest singular values that are needed
+		to reach the 'energy' specified by `svd_rank`; if -1, the method does
+		not compute truncation.
+	:type svd_rank: int or float
 	:param int tlsq_rank: rank truncation computing Total Least Square. Default
 		is 0, that means no truncation.
 	:param bool exact: flag to compute either exact DMD or projected DMD.

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -217,10 +217,13 @@ class DMDBase(object):
 		Truncated Singular Value Decomposition.
 
 		:param numpy.ndarray X: the matrix to decompose.
-		:param int svd_rank: the rank for the truncation; If 0, the method
-			computes the optimal rank and uses it for truncation; if positive
-			number, the method uses the argument for the truncation; if -1, the
-			method does not compute truncation.
+		:param svd_rank: the rank for the truncation; If 0, the method computes
+			the optimal rank and uses it for truncation; if positive interger,
+			the method uses the argument for the truncation; if float between 0
+			and 1, the rank is the number of the biggest singular values that
+			are needed to reach the 'energy' specified by `svd_rank`; if -1,
+			the method does not compute truncation.
+		:type svd_rank: int or float
 		:return: the truncated left-singular vectors matrix, the truncated
 			singular values array, the truncated right-singular vectors matrix.
 		:rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
@@ -239,7 +242,10 @@ class DMDBase(object):
 			beta = np.divide(*sorted(X.shape))
 			tau = np.median(s) * omega(beta)
 			rank = np.sum(s > tau)
-		elif svd_rank > 0:
+		elif svd_rank > 0 and svd_rank < 1:
+			cumulative_energy = np.cumsum(s / s.sum())
+			rank = np.searchsorted(cumulative_energy, svd_rank) + 1 
+		elif svd_rank >= 1 and isinstance(svd_rank, int):
 			rank = min(svd_rank, U.shape[1])
 		else:
 			rank = X.shape[1]

--- a/pydmd/fbdmd.py
+++ b/pydmd/fbdmd.py
@@ -11,12 +11,13 @@ class FbDMD(DMDBase):
 	"""
 	Forward/backward DMD class.
 
-	:param int svd_rank: rank truncation in SVD. Default is 0, that means no
-		truncation.
-	:param int svd_rank: rank truncation in SVD. If 0, the method computes the
-		optimal rank and uses it for truncation; if positive number, the method
-		uses the argument for the truncation; if -1, the method does not
-		compute truncation.
+	:param svd_rank: the rank for the truncation; If 0, the method computes the
+		optimal rank and uses it for truncation; if positive interger, the
+		method uses the argument for the truncation; if float between 0 and 1,
+		the rank is the number of the biggest singular values that are needed
+		to reach the 'energy' specified by `svd_rank`; if -1, the method does
+		not compute truncation.
+	:type svd_rank: int or float
 	:param int tlsq_rank: rank truncation computing Total Least Square. Default
 		is 0, that means no truncation.
 	:param bool exact: flag to compute either exact DMD or projected DMD.

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -19,10 +19,13 @@ class MrDMD(DMDBase):
 	"""
 	Multi-resolution Dynamic Mode Decomposition
 
-	:param int svd_rank: rank truncation in SVD. If 0, the method computes the
-		optimal rank and uses it for truncation; if positive number, the method
-		uses the argument for the truncation; if -1, the method does not
-		compute truncation.
+	:param svd_rank: the rank for the truncation; If 0, the method computes the
+		optimal rank and uses it for truncation; if positive interger, the
+		method uses the argument for the truncation; if float between 0 and 1,
+		the rank is the number of the biggest singular values that are needed
+		to reach the 'energy' specified by `svd_rank`; if -1, the method does
+		not compute truncation.
+	:type svd_rank: int or float
 	:param int tlsq_rank: rank truncation computing Total Least Square. Default
 		is 0, that means no truncation.
 	:param bool exact: flag to compute either exact DMD or projected DMD.

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -43,6 +43,11 @@ class TestDmd(TestCase):
 		dmd.fit(X=sample_data)
 		assert dmd.modes.shape[1] == 3
 
+	def test_rank(self):
+		dmd = DMD(svd_rank=0.9)
+		dmd.fit(X=sample_data)
+		assert len(dmd.eigs) == 2
+
 	def test_Atilde_shape(self):
 		dmd = DMD(svd_rank=3)
 		dmd.fit(X=sample_data)


### PR DESCRIPTION
Add the possibility to chose the rank for truncated svd using the
cumulative energy of the ordered singular values