### PR TITLE
optdmd.py - missing return self in fit method

### DIFF
--- a/pydmd/optdmd.py
+++ b/pydmd/optdmd.py
@@ -129,6 +129,8 @@ class OptDMD(DMDBase):
             _, self._input_space, self._output_space = self._eig_from_lowrank_op(self._Atilde, Uz, Q)
 
         self._modes = self._output_space
+        
+        return self
 
     def predict(self, X):
         """


### PR DESCRIPTION
I believe the fit method is missing the return self call. I noticed this when running Tutorial 8, which threw errors but now works after making this fix. (PS Thanks for making this package!)