### PR TITLE
Fix #120 through introducing original t0 in dynamics

### DIFF
--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -124,8 +124,9 @@ class DMDBase(object):
         :rtype: numpy.ndarray
         """
         omega = old_div(np.log(self.eigs), self.original_time['dt'])
-        vander = np.exp(np.multiply(*np.meshgrid(omega, self.dmd_timesteps)))
-        return (vander * self._b).T
+        vander = np.exp(
+            np.outer(omega, self.dmd_timesteps - self.original_time['t0']))
+        return vander * self._b[:, None]
 
     @property
     def reconstructed_data(self):


### PR DESCRIPTION
It was implicitly assumed that the initial snapshot corresponds to `t = 0`. This PR brings meaning to the existing attribute `dmd.original_time["t0"]`which is now used when constructing the dynamics of the system.

The issue #120 is now fixed by this PR.

Unit tests are passing.