### PR TITLE
Fix division by zero in MrDMD class

### DIFF
--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -76,12 +76,18 @@ class MrDMD(DMDBase):
         :return: the matrix that contains the reconstructed snapshots.
         :rtype: numpy.ndarray
         """
-        data = np.sum(
-            np.array([
-                self.partial_reconstructed_data(i)
-                for i in range(self.max_level)
-            ]),
-            axis=0)
+        try:
+            data = np.sum(
+                np.array([
+                    self.partial_reconstructed_data(i)
+                    for i in range(self.max_level)
+                ]),
+                axis=0)
+        except MemoryError:
+            data = np.array(self.partial_reconstructed_data(0))
+            for i in range(1, self.max_level):
+                data = np.sum([data,
+                np.array(self.partial_reconstructed_data(i))], axis=0)
         return data
 
     @property

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from pydmd.mrdmd import MrDMD
 import matplotlib.pyplot as plt
 import numpy as np
-
+import unittest
 
 def create_data():
     x = np.linspace(-10, 10, 80)
@@ -38,6 +38,13 @@ sample_data = create_data()
 
 
 class TestMrDmd(TestCase):
+    def test_max_level_threshold(self):
+        level = 10
+        dmd = MrDMD(svd_rank=1, max_level=level, max_cycles=2)
+        dmd.fit(X=sample_data)
+        lvl_threshold = int(np.log(sample_data.shape[1]/4.)/np.log(2.)) - 1
+        assert lvl_threshold == dmd.max_level
+
     def test_shape_modes(self):
         level = 5
         dmd = MrDMD(svd_rank=1, max_level=level, max_cycles=2)
@@ -194,3 +201,7 @@ class TestMrDmd(TestCase):
         dmd.fit(X=sample_data)
         dmd.plot_eigs(show_axes=False, show_unit_circle=False, level=1, node=0)
         plt.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Dear,

As described in issue #122, here follows a proposal for fixing the division by zero in the multi-resolution DMD. The problem was being caused by the null eigenpairs in the `fit` method when the number of resolution levels defined by the user was large.

In the proposed pull request, a refactor was made only inside `fit` method. It is worth mentioning that this fix does not alter the solutions of the method, but avoids the zero-valued modes that were causing the problem in the reconstruction.

This pull request also includes a solution for the eventual `MemoryError` that raises when dealing with large matrices and large number of resolution levels. 

Best,
Renato Miotto