### PR TITLE
Fixes for parameter `rescale_mode`, and some tests

### DIFF
--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -115,7 +115,8 @@ class CDMD(DMDBase):
 
         # No projected modes for cdmd
         self._eigs, self._modes = self._eig_from_lowrank_op(
-            self._Atilde, self._snapshots[:, 1:], U, s, V, True)
+            self._Atilde, self._snapshots[:, 1:], U, s, V, True,
+            rescale_mode=self.rescale_mode)
 
         # Default timesteps
         self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -59,7 +59,8 @@ class DMD(DMDBase):
         self._svd_modes = U
 
         self._eigs, self._modes = self._eig_from_lowrank_op(
-            self._Atilde, Y, U, s, V, self.exact)
+            self._Atilde, Y, U, s, V, self.exact,
+            rescale_mode=self.rescale_mode)
 
         # Default timesteps
         self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -356,16 +356,21 @@ class DMDBase(object):
             # scaling isn't required
             Ahat = Atilde
         else:
-            # rescale using the singular values (as done in the paper)
+            # rescale using singular values (like in Section 2.4 of
+            # https://arxiv.org/pdf/1409.5496.pdf)
             if rescale_mode == 'auto':
                 scaling_factors_array = s.copy()
             # rescale using custom values
             else:
+                if len(rescale_mode) != len(s):
+                    raise ValueError('''Scaling by an invalid number of
+                        coefficients''')
+
                 scaling_factors_array = rescale_mode
 
             factors_inv_sqrt = np.diag(np.power(scaling_factors_array, -0.5))
             factors_sqrt = np.diag(np.power(scaling_factors_array, 0.5))
-            Ahat = factors_inv_sqrt.dot(atilde).dot(factors_sqrt)
+            Ahat = factors_inv_sqrt.dot(Atilde).dot(factors_sqrt)
 
         lowrank_hat_eigenvalues, lowrank_hat_eigenvectors = np.linalg.eig(Ahat)
 

--- a/pydmd/fbdmd.py
+++ b/pydmd/fbdmd.py
@@ -65,7 +65,8 @@ class FbDMD(DMDBase):
         self._Atilde = sqrtm(fAtilde.dot(np.linalg.inv(bAtilde)))
 
         self._eigs, self._modes = self._eig_from_lowrank_op(
-            self._Atilde, Y, Ux, sx, Vx, self.exact)
+            self._Atilde, Y, Ux, sx, Vx, self.exact,
+            rescale_mode=self.rescale_mode)
 
         self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
         self.dmd_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -65,7 +65,8 @@ class HODMD(DMDBase):
         self._Atilde = self._build_lowrank_op(U, s, V, Y)
 
         self._eigs, self._modes = self._eig_from_lowrank_op(
-            self._Atilde, Y, U, s, V, self.exact)
+            self._Atilde, Y, U, s, V, self.exact,
+            rescale_mode=self.rescale_mode)
         self._modes = self._modes[:self._snapshots.shape[0], :]
 
         # Default timesteps

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -392,7 +392,7 @@ class MrDMD(DMDBase):
             Atilde = self._build_lowrank_op(U, s, V, Yc)
 
             eigs, modes = self._eig_from_lowrank_op(Atilde, Yc, U, s, V,
-                                                    self.exact)
+                self.exact, rescale_mode=self.rescale_mode)
             rho = old_div(float(self.max_cycles), n_samples)
             slow_modes = (np.abs(
                 old_div(np.log(eigs), (2. * np.pi * step)))) <= rho

--- a/pydmd/optdmd.py
+++ b/pydmd/optdmd.py
@@ -59,11 +59,6 @@ class OptDMD(DMDBase):
         Default is False.
     :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
         Default is False.
-    :param rescale_mode: Scale Atilde as shown in
-            10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its
-            eigendecomposition. None means no rescaling, 'auto' means automatic
-            rescaling using singular values, otherwise the scaling factors.
-    :type rescale_mode: {'auto'} or None or numpy.ndarray
     """
 
     def __init__(self,


### PR DESCRIPTION
Modifications introduced in #151 are not effective at the moment since the class parameter `rescale_mode` isn't passed to `fit()`. This pull requests fixes this problem.
Moreover it also adds some tests to control the behavior of the new parameter `rescale_mode`, and some minor fixes.