### PR TITLE
Set Travis osx_image explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           python: 3.6
           env: TOXENV=py36
         - os: osx
+          osx_image: xcode12.2
           language: generic
           env: TOXENV=py36
           


### PR DESCRIPTION
Following the suggestion of @mtezzele I'm trying to fix the failing osx build setting the `osx_image` attribute explicitly to macOS 10.15.7. 