### PR TITLE
DMD parameter 'amplitudes_snapshot_index'

### DIFF
--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -117,10 +117,21 @@ class CDMD(DMDBase):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
+        used to compute DMD modes amplitudes. The reconstruction will generally
+        be better in time instants near the chosen snapshot; however increasing
+        this value may lead to wrong results when the system presents small
+        eigenvalues. For this reason a manual selection of the number of
+        eigenvalues in the system may be needed (check svd_rank). Also setting
+        svd_rank to a value between 0 and 1 can lead to better results. Default
+        value is 0.
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, compression_matrix='uniform',
-        opt=False, rescale_mode=None, forward_backward=False):
+        opt=False, rescale_mode=None, forward_backward=False,
+        amplitudes_snapshot_index=0):
+
+        self._amplitudes_snapshot_index = amplitudes_snapshot_index
         self._tlsq_rank = tlsq_rank
         self._opt = opt
         self._compression_matrix = compression_matrix

--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -107,9 +107,9 @@ class CDMD(DMDBase):
         is '`uniform`'.
     :type compression_matrix: {'linear', 'sparse', 'uniform', 'sample'} or
         numpy.ndarray
-    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
-    :type opt: bool or int.
+    :param opt: argument to control the computation of DMD modes amplitudes. See
+        :class:`DMDBase`. Default is False.
+    :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its
             eigendecomposition. None means no rescaling, 'auto' means automatic

--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -107,8 +107,9 @@ class CDMD(DMDBase):
         is '`uniform`'.
     :type compression_matrix: {'linear', 'sparse', 'uniform', 'sample'} or
         numpy.ndarray
-    :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
+    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
         Default is False.
+    :type opt: bool or int.
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its
             eigendecomposition. None means no rescaling, 'auto' means automatic
@@ -117,21 +118,11 @@ class CDMD(DMDBase):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
-    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
-        used to compute DMD modes amplitudes. The reconstruction will generally
-        be better in time instants near the chosen snapshot; however increasing
-        this value may lead to wrong results when the system presents small
-        eigenvalues. For this reason a manual selection of the number of
-        eigenvalues in the system may be needed (check svd_rank). Also setting
-        svd_rank to a value between 0 and 1 can lead to better results. Default
-        value is 0.
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, compression_matrix='uniform',
-        opt=False, rescale_mode=None, forward_backward=False,
-        amplitudes_snapshot_index=0):
+        opt=False, rescale_mode=None, forward_backward=False):
 
-        self._amplitudes_snapshot_index = amplitudes_snapshot_index
         self._tlsq_rank = tlsq_rank
         self._opt = opt
         self._compression_matrix = compression_matrix

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -40,6 +40,14 @@ class DMD(DMDBase):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
+        used to compute DMD modes amplitudes. The reconstruction will generally
+        be better in time instants near the chosen snapshot; however increasing
+        this value may lead to wrong results when the system presents small
+        eigenvalues. For this reason a manual selection of the number of
+        eigenvalues in the system may be needed (check svd_rank). Also setting
+        svd_rank to a value between 0 and 1 can lead to better results. Default
+        value is 0.
     """
 
     def fit(self, X):

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -30,8 +30,8 @@ class DMD(DMDBase):
         is 0, that means TLSQ is not applied.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param opt: argument to control the computation of DMD modes amplitudes. See
+        :class:`DMDBase`. Default is False.
     :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -30,8 +30,9 @@ class DMD(DMDBase):
         is 0, that means TLSQ is not applied.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
+    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
         Default is False.
+    :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its
             eigendecomposition. None means no rescaling, 'auto' means automatic
@@ -40,14 +41,6 @@ class DMD(DMDBase):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
-    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
-        used to compute DMD modes amplitudes. The reconstruction will generally
-        be better in time instants near the chosen snapshot; however increasing
-        this value may lead to wrong results when the system presents small
-        eigenvalues. For this reason a manual selection of the number of
-        eigenvalues in the system may be needed (check svd_rank). Also setting
-        svd_rank to a value between 0 and 1 can lead to better results. Default
-        value is 0.
     """
 
     def fit(self, X):

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -32,8 +32,7 @@ class DMDBase(object):
         is 0, that means no truncation.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param opt: flag to control the computation of DMD amplitudes. If True,
-        amplitudes are computed like in optimized DMD  (see
+    :param opt: If True, amplitudes are computed like in optimized DMD  (see
         :func:`~dmdbase.DMDBase._compute_amplitudes` for reference). If
         False, amplitudes are computed following the standard algorithm. If
         `opt` is an integer, it is used as the (temporal) index of the snapshot

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -41,6 +41,14 @@ class DMDBase(object):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
+        used to compute DMD modes amplitudes. The reconstruction will generally
+        be better in time instants near the chosen snapshot; however increasing
+        this value may lead to wrong results when the system presents small
+        eigenvalues. For this reason a manual selection of the number of
+        eigenvalues in the system may be needed (check svd_rank). Also setting
+        svd_rank to a value between 0 and 1 can lead to better results. Default
+        value is 0.
 
     :cvar dict original_time: dictionary that contains information about the
         time window where the system is sampled:
@@ -59,7 +67,8 @@ class DMDBase(object):
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, forward_backward=False):
+        rescale_mode=None, forward_backward=False,
+        amplitudes_snapshot_index=0):
         self._Atilde = DMDOperator(svd_rank=svd_rank, exact=exact,
             rescale_mode=rescale_mode, forward_backward=forward_backward)
 
@@ -67,6 +76,7 @@ class DMDBase(object):
         self.original_time = None
         self.dmd_time = None
         self._opt = opt
+        self._amplitudes_snapshot_index = amplitudes_snapshot_index
 
         self._b = None  # amplitudes
         self._snapshots = None
@@ -160,6 +170,22 @@ class DMDBase(object):
         """
         return self.operator.eigenvalues
 
+    def _translate_eigs_exponent(self, tpow):
+        """
+        Get the eigenvalues of A tilde.
+
+        :param tpow: the exponent(s) of Sigma in the original DMD formula.
+        :type tpow: int or np.ndarray
+        :return: the eigenvalues from the eigendecomposition of `atilde`.
+        :rtype: numpy.ndarray
+        """
+
+        if self._amplitudes_snapshot_index < 0:
+            # we take care of negative indexes: -n becomes T - n
+            return tpow - (self.snapshots.shape[1] + self._amplitudes_snapshot_index)
+        else:
+            return tpow - self._amplitudes_snapshot_index
+
     @property
     def dynamics(self):
         """
@@ -180,7 +206,14 @@ class DMDBase(object):
         tpow = old_div(self.dmd_timesteps - self.original_time['t0'],
                        self.original_time['dt'])
 
-        return np.power(temp, tpow) * self._b[:, None]
+        # The new formula is x_(k+j) = \Phi \Lambda^k \Phi^(-1) x_j.
+        # Since j is fixed, for a given snapshot "u" we have the following
+        # formula:
+        # x_u = \Phi \Lambda^{u-j} \Phi^(-1) x_j
+        # Therefore tpow must be scaled appropriately.
+        tpow = self._translate_eigs_exponent(tpow)
+
+        return (np.power(temp, tpow) * self._b[:, None])
 
     @property
     def reconstructed_data(self):
@@ -308,7 +341,9 @@ class DMDBase(object):
             # b optimal
             a = np.linalg.solve(P, q)
         else:
-            a = np.linalg.lstsq(self.modes, self._snapshots.T[0], rcond=None)[0]
+            a = np.linalg.lstsq(self.modes,
+                self._snapshots.T[self._amplitudes_snapshot_index],
+                rcond=None)[0]
 
         return a
 

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -169,8 +169,17 @@ class DMDc(DMDBase):
         equal than `svd_rank`. For the possible values please refer to the
         `svd_rank` parameter description above.
     :type svd_rank_omega: int or float
+    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
+        used to compute DMD modes amplitudes. The reconstruction will generally
+        be better in time instants near the chosen snapshot; however increasing
+        this value may lead to wrong results when the system presents small
+        eigenvalues. For this reason a manual selection of the number of
+        eigenvalues in the system may be needed (check svd_rank). Also setting
+        svd_rank to a value between 0 and 1 can lead to better results. Default
+        value is 0.
     """
-    def __init__(self, svd_rank=0, tlsq_rank=0, opt=False, svd_rank_omega=-1):
+    def __init__(self, svd_rank=0, tlsq_rank=0, opt=False, svd_rank_omega=-1,
+        amplitudes_snapshot_index=0):
 
         # we're going to initialize Atilde when we know if B is known
         self._Atilde = None
@@ -182,6 +191,7 @@ class DMDc(DMDBase):
         }
 
         self._opt = opt
+        self._amplitudes_snapshot_index = amplitudes_snapshot_index
 
         self._B = None
         self._snapshots_shape = None

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -161,25 +161,17 @@ class DMDc(DMDBase):
     :type svd_rank: int or float
     :param int tlsq_rank: rank truncation computing Total Least Square. Default
         is 0, that means no truncation.
-    :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
+    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
         Default is False.
+    :type opt: bool or int
     :param svd_rank_omega: the rank for the truncation of the aumented matrix
         omega composed by the left snapshots matrix and the control. Used only
         for the `_fit_B_unknown` method of this class. It should be greater or
         equal than `svd_rank`. For the possible values please refer to the
         `svd_rank` parameter description above.
     :type svd_rank_omega: int or float
-    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
-        used to compute DMD modes amplitudes. The reconstruction will generally
-        be better in time instants near the chosen snapshot; however increasing
-        this value may lead to wrong results when the system presents small
-        eigenvalues. For this reason a manual selection of the number of
-        eigenvalues in the system may be needed (check svd_rank). Also setting
-        svd_rank to a value between 0 and 1 can lead to better results. Default
-        value is 0.
     """
-    def __init__(self, svd_rank=0, tlsq_rank=0, opt=False, svd_rank_omega=-1,
-        amplitudes_snapshot_index=0):
+    def __init__(self, svd_rank=0, tlsq_rank=0, opt=False, svd_rank_omega=-1):
 
         # we're going to initialize Atilde when we know if B is known
         self._Atilde = None
@@ -191,7 +183,6 @@ class DMDc(DMDBase):
         }
 
         self._opt = opt
-        self._amplitudes_snapshot_index = amplitudes_snapshot_index
 
         self._B = None
         self._snapshots_shape = None

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -161,8 +161,8 @@ class DMDc(DMDBase):
     :type svd_rank: int or float
     :param int tlsq_rank: rank truncation computing Total Least Square. Default
         is 0, that means no truncation.
-    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param opt: argument to control the computation of DMD modes amplitudes. See
+        :class:`DMDBase`. Default is False.
     :type opt: bool or int
     :param svd_rank_omega: the rank for the truncation of the aumented matrix
         omega composed by the left snapshots matrix and the control. Used only

--- a/pydmd/fbdmd.py
+++ b/pydmd/fbdmd.py
@@ -22,26 +22,19 @@ class FbDMD(DMD):
         is 0, that means no truncation.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param bool opt: flag to compute optimized DMD. Default is False.
+    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
+        Default is False.
+    :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its
             eigendecomposition. None means no rescaling, 'auto' means automatic
             rescaling using singular values, otherwise the scaling factors.
     :type rescale_mode: {'auto'} or None or numpy.ndarray
-    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
-        used to compute DMD modes amplitudes. The reconstruction will generally
-        be better in time instants near the chosen snapshot; however increasing
-        this value may lead to wrong results when the system presents small
-        eigenvalues. For this reason a manual selection of the number of
-        eigenvalues in the system may be needed (check svd_rank). Also setting
-        svd_rank to a value between 0 and 1 can lead to better results. Default
-        value is 0.
 
     Reference: Dawson et al. https://arxiv.org/abs/1507.02264
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, amplitudes_snapshot_index=0):
+        rescale_mode=None):
         super().__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank, exact=exact,
-            opt=opt, rescale_mode=rescale_mode, forward_backward=True,
-            amplitudes_snapshot_index=amplitudes_snapshot_index)
+            opt=opt, rescale_mode=rescale_mode, forward_backward=True)

--- a/pydmd/fbdmd.py
+++ b/pydmd/fbdmd.py
@@ -22,8 +22,8 @@ class FbDMD(DMD):
         is 0, that means no truncation.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param opt: argument to control the computation of DMD modes amplitudes. See
+        :class:`DMDBase`. Default is False.
     :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its

--- a/pydmd/fbdmd.py
+++ b/pydmd/fbdmd.py
@@ -28,11 +28,20 @@ class FbDMD(DMD):
             eigendecomposition. None means no rescaling, 'auto' means automatic
             rescaling using singular values, otherwise the scaling factors.
     :type rescale_mode: {'auto'} or None or numpy.ndarray
+    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
+        used to compute DMD modes amplitudes. The reconstruction will generally
+        be better in time instants near the chosen snapshot; however increasing
+        this value may lead to wrong results when the system presents small
+        eigenvalues. For this reason a manual selection of the number of
+        eigenvalues in the system may be needed (check svd_rank). Also setting
+        svd_rank to a value between 0 and 1 can lead to better results. Default
+        value is 0.
 
     Reference: Dawson et al. https://arxiv.org/abs/1507.02264
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None):
+        rescale_mode=None, amplitudes_snapshot_index=0):
         super().__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank, exact=exact,
-            opt=opt, rescale_mode=rescale_mode, forward_backward=True)
+            opt=opt, rescale_mode=rescale_mode, forward_backward=True,
+            amplitudes_snapshot_index=amplitudes_snapshot_index)

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -26,7 +26,9 @@ class HODMD(DMDBase):
         is 0, that means no truncation.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param bool opt: flag to compute optimized DMD. Default is False.
+    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
+        Default is False.
+    :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its
             eigendecomposition. None means no rescaling, 'auto' means automatic
@@ -37,22 +39,12 @@ class HODMD(DMDBase):
         False.
     :param int d: the new order for spatial dimension of the input snapshots.
         Default is 1.
-    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
-        used to compute DMD modes amplitudes. The reconstruction will generally
-        be better in time instants near the chosen snapshot; however increasing
-        this value may lead to wrong results when the system presents small
-        eigenvalues. For this reason a manual selection of the number of
-        eigenvalues in the system may be needed (check svd_rank). Also setting
-        svd_rank to a value between 0 and 1 can lead to better results. Default
-        value is 0.
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, forward_backward=False, d=1,
-        amplitudes_snapshot_index=0):
+        rescale_mode=None, forward_backward=False, d=1):
         super(HODMD, self).__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank,
-            exact=exact, opt=opt, rescale_mode=rescale_mode,
-            amplitudes_snapshot_index=amplitudes_snapshot_index)
+            exact=exact, opt=opt, rescale_mode=rescale_mode)
         self._d = d
 
     @property

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -37,12 +37,22 @@ class HODMD(DMDBase):
         False.
     :param int d: the new order for spatial dimension of the input snapshots.
         Default is 1.
+    :param int amplitudes_snapshot_index: The (temporal) index of the snapshot
+        used to compute DMD modes amplitudes. The reconstruction will generally
+        be better in time instants near the chosen snapshot; however increasing
+        this value may lead to wrong results when the system presents small
+        eigenvalues. For this reason a manual selection of the number of
+        eigenvalues in the system may be needed (check svd_rank). Also setting
+        svd_rank to a value between 0 and 1 can lead to better results. Default
+        value is 0.
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, forward_backward=False, d=1):
+        rescale_mode=None, forward_backward=False, d=1,
+        amplitudes_snapshot_index=0):
         super(HODMD, self).__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank,
-            exact=exact, opt=opt, rescale_mode=rescale_mode)
+            exact=exact, opt=opt, rescale_mode=rescale_mode,
+            amplitudes_snapshot_index=amplitudes_snapshot_index)
         self._d = d
 
     @property

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -26,8 +26,8 @@ class HODMD(DMDBase):
         is 0, that means no truncation.
     :param bool exact: flag to compute either exact DMD or projected DMD.
         Default is False.
-    :param opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param opt: argument to control the computation of DMD modes amplitudes. See
+        :class:`DMDBase`. Default is False.
     :type opt: bool or int
     :param rescale_mode: Scale Atilde as shown in
             10.1016/j.jneumeth.2015.10.010 (section 2.4) before computing its

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -129,8 +129,9 @@ class MrDMDOperator(DMDOperator):
     :param int max_cycles: the maximum number of mode oscillations in any given
         time scale. Default is 1.
     :param int max_level: the maximum number of levels. Defualt is 6.
-    :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param bool opt: flag to compute optimal amplitudes. Default is False.
+        Doesn't support changing the temporal index of the snapshot used for the
+        computation of DMD modes amplitudes.
     """
 
     def __init__(self, svd_rank, tlsq_rank, max_cycles, max_level, opt):
@@ -230,8 +231,9 @@ class MrDMD(DMDBase):
     :type svd_rank: int or float
     :param int tlsq_rank: rank truncation computing Total Least Square. Default
         is 0, that means TLSQ is not applied.
-    :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param bool opt: flag to compute optimal amplitudes. Default is False.
+        Doesn't support changing the temporal index of the snapshot used for the
+        computation of DMD modes amplitudes.
     :param int max_cycles: the maximum number of mode oscillations in any given
         time scale. Default is 1.
     :param int max_level: the maximum number of levels. Defualt is 6.

--- a/pydmd/optdmd.py
+++ b/pydmd/optdmd.py
@@ -149,8 +149,9 @@ class OptDMD(DMDBase):
     :type svd_rank: int or float
     :param int tlsq_rank: rank truncation computing Total Least Square. Default
         is 0, that means TLSQ is not applied.
-    :param bool opt: flag to compute optimal amplitudes. See :class:`DMDBase`.
-        Default is False.
+    :param opt: argument to control the computation of DMD modes amplitudes. See
+        :class:`DMDBase`. Default is False.
+    :type opt: bool or int
     """
 
     def __init__(self, factorization="evd", svd_rank=0, tlsq_rank=0, opt=False):

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -378,7 +378,7 @@ class TestDmd(TestCase):
         dmd = DMD(svd_rank=0.99)
         dmd.fit(sample_data)
 
-        dmd2 = DMD(svd_rank=0.99, amplitudes_snapshot_index=-1)
+        dmd2 = DMD(svd_rank=0.99, opt=-1)
         dmd2.fit(sample_data)
 
         np.testing.assert_almost_equal(dmd2.reconstructed_data.real,

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -371,4 +371,15 @@ class TestDmd(TestCase):
 
         np.testing.assert_almost_equal(dmd
             .fit(sample_data)
-            .predict(sample_data[:,10:30]), expected, decimal=6)
+            .predict(sample_data[:, 10:30]), expected, decimal=6)
+
+
+    def test_advanced_snapshot_parameter(self):
+        dmd = DMD(svd_rank=0.99)
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=0.99, amplitudes_snapshot_index=-1)
+        dmd2.fit(sample_data)
+
+        np.testing.assert_almost_equal(dmd2.reconstructed_data.real,
+            dmd.reconstructed_data.real, decimal=6)

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -62,3 +62,32 @@ class TestDmdBase(TestCase):
         dmd = DMDBase()
         with self.assertRaises(ValueError):
             dmd.plot_snapshots_2D()
+
+    def test_advanced_snapshot_parameter(self):
+        dmd = DMDBase()
+        assert dmd._amplitudes_snapshot_index == 0
+
+    def test_advanced_snapshot_parameter2(self):
+        dmd = DMDBase(amplitudes_snapshot_index=5)
+        assert dmd._amplitudes_snapshot_index == 5
+
+    def test_translate_tpow_positive(self):
+        dmd = DMDBase(amplitudes_snapshot_index=4)
+
+        assert dmd._translate_eigs_exponent(10) == 6
+        assert dmd._translate_eigs_exponent(0) == -4
+
+    def test_translate_tpow_negative(self):
+        dmd = DMDBase(amplitudes_snapshot_index=-1)
+        dmd._snapshots = sample_data
+
+        assert dmd._translate_eigs_exponent(10) == 10 - (sample_data.shape[1] - 1)
+        assert dmd._translate_eigs_exponent(0) == 1 - sample_data.shape[1]
+
+    def test_translate_tpow_vector(self):
+        dmd = DMDBase(amplitudes_snapshot_index=-1)
+        dmd._snapshots = sample_data
+
+        tpow = np.ndarray([0,1,2,3,5,6,7,11])
+        for idx,x in enumerate(dmd._translate_eigs_exponent(tpow)):
+            assert x == dmd._translate_eigs_exponent(tpow[idx])

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -63,29 +63,25 @@ class TestDmdBase(TestCase):
         with self.assertRaises(ValueError):
             dmd.plot_snapshots_2D()
 
-    def test_advanced_snapshot_parameter(self):
-        dmd = DMDBase()
-        assert dmd._amplitudes_snapshot_index == 0
-
     def test_advanced_snapshot_parameter2(self):
-        dmd = DMDBase(amplitudes_snapshot_index=5)
-        assert dmd._amplitudes_snapshot_index == 5
+        dmd = DMDBase(opt=5)
+        assert dmd.opt == 5
 
     def test_translate_tpow_positive(self):
-        dmd = DMDBase(amplitudes_snapshot_index=4)
+        dmd = DMDBase(opt=4)
 
         assert dmd._translate_eigs_exponent(10) == 6
         assert dmd._translate_eigs_exponent(0) == -4
 
     def test_translate_tpow_negative(self):
-        dmd = DMDBase(amplitudes_snapshot_index=-1)
+        dmd = DMDBase(opt=-1)
         dmd._snapshots = sample_data
 
         assert dmd._translate_eigs_exponent(10) == 10 - (sample_data.shape[1] - 1)
         assert dmd._translate_eigs_exponent(0) == 1 - sample_data.shape[1]
 
     def test_translate_tpow_vector(self):
-        dmd = DMDBase(amplitudes_snapshot_index=-1)
+        dmd = DMDBase(opt=-1)
         dmd._snapshots = sample_data
 
         tpow = np.ndarray([0,1,2,3,5,6,7,11])


### PR DESCRIPTION
In this commit I introduced the `DMDBase` parameter `amplitudes_snapshot_index`, which allows setting a time snapshot (which may not be the first one) to be used for the computation of DMD modes amplitudes. This results in a slight improvement of `reconstructed_data` in time instants near the chosen snapshot.

![image](https://user-images.githubusercontent.com/8464342/112222087-8d2c4000-8c28-11eb-901c-3daff0476077.png)

The two plots trepresent the error between the original function and the representation in `dmd.reconstructed_data` (time grows vertically). In the plot on the left I used the parameter `amplitudes_snapshot_index=0` (first snapshot), while in the plot on the right `amplitudes_snapshot_index=-1` (which means the last time snapshot).<br>As you can see in both cases the error vanishes as we approach the selected snapshot.

However the approach used has some limitations. When `Atilde` has small eigenvalues we observe a "blow-up" of the dynamics of the system (due to the negative power in the formula), which leads to wrong results. I observed that in some cases this is fixed by setting `svd_rank` to a value between 0 and 1, in order to select only "massive" eigenvalues.