### PR TITLE
Sort eigenvalues/modes/dynamics automatically

### DIFF
--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -32,11 +32,16 @@ class CDMDOperator(DMDOperator):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`. Default: False.
+    :type sorted_eigs: {'real', 'abs'} or False
     """
 
-    def __init__(self, svd_rank, rescale_mode, forward_backward):
+    def __init__(self, svd_rank, rescale_mode, forward_backward, sorted_eigs):
         super().__init__(svd_rank=svd_rank, exact=True,
-            rescale_mode=rescale_mode, forward_backward=forward_backward)
+            rescale_mode=rescale_mode, forward_backward=forward_backward,
+            sorted_eigs=sorted_eigs)
 
     def compute_operator(self, compressedX, compressedY, nonCompressedY):
         """
@@ -118,17 +123,26 @@ class CDMD(DMDBase):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`.
+    :type sorted_eigs: {'real', 'abs'} or False
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`. Default: False.
+    :type sorted_eigs: {'real', 'abs'} or False
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, compression_matrix='uniform',
-        opt=False, rescale_mode=None, forward_backward=False):
+        opt=False, rescale_mode=None, forward_backward=False, sorted_eigs=False):
 
         self._tlsq_rank = tlsq_rank
         self._opt = opt
         self._compression_matrix = compression_matrix
 
         self._Atilde = CDMDOperator(svd_rank=svd_rank,
-            rescale_mode=rescale_mode, forward_backward=forward_backward)
+            rescale_mode=rescale_mode, forward_backward=forward_backward,
+            sorted_eigs=sorted_eigs)
 
     @property
     def compression_matrix(self):

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -41,6 +41,10 @@ class DMD(DMDBase):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`. Default: False.
+    :type sorted_eigs: {'real', 'abs'} or False
     """
 
     def fit(self, X):

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -52,6 +52,10 @@ class DMDBase(object):
     :param bool forward_backward: If True, the low-rank operator is computed
         like in fbDMD (reference: https://arxiv.org/abs/1507.02264). Default is
         False.
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`. Default: False.
+    :type sorted_eigs: {'real', 'abs'} or False
 
     :cvar dict original_time: dictionary that contains information about the
         time window where the system is sampled:
@@ -70,9 +74,10 @@ class DMDBase(object):
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, forward_backward=False):
+        rescale_mode=None, forward_backward=False, sorted_eigs=False):
         self._Atilde = DMDOperator(svd_rank=svd_rank, exact=exact,
-            rescale_mode=rescale_mode, forward_backward=forward_backward)
+            rescale_mode=rescale_mode, forward_backward=forward_backward,
+            sorted_eigs=sorted_eigs)
 
         self._tlsq_rank = tlsq_rank
         self.original_time = None

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -36,7 +36,7 @@ class DMDControlOperator(DMDOperator):
 
     def __init__(self, svd_rank, svd_rank_omega, tlsq_rank):
         super(DMDControlOperator, self).__init__(svd_rank=svd_rank, exact=True,
-            rescale_mode=None, forward_backward=False)
+            rescale_mode=None, forward_backward=False, sorted_eigs=False)
         self._svd_rank_omega = svd_rank_omega
         self._tlsq_rank = tlsq_rank
 

--- a/pydmd/fbdmd.py
+++ b/pydmd/fbdmd.py
@@ -30,11 +30,16 @@ class FbDMD(DMD):
             eigendecomposition. None means no rescaling, 'auto' means automatic
             rescaling using singular values, otherwise the scaling factors.
     :type rescale_mode: {'auto'} or None or numpy.ndarray
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`. Default: False.
+    :type sorted_eigs: {'real', 'abs'} or False
 
     Reference: Dawson et al. https://arxiv.org/abs/1507.02264
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None):
+        rescale_mode=None, sorted_eigs=False):
         super().__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank, exact=exact,
-            opt=opt, rescale_mode=rescale_mode, forward_backward=True)
+            opt=opt, rescale_mode=rescale_mode, forward_backward=True,
+            sorted_eigs=sorted_eigs)

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -39,12 +39,17 @@ class HODMD(DMDBase):
         False.
     :param int d: the new order for spatial dimension of the input snapshots.
         Default is 1.
+    :param sorted_eigs: Sort eigenvalues (and modes/dynamics accordingly) by
+        magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
+        part to break ties) if `sorted_eigs='real'`. Default: False.
+    :type sorted_eigs: {'real', 'abs'} or False
     """
 
     def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, forward_backward=False, d=1):
+        rescale_mode=None, forward_backward=False, d=1, sorted_eigs=False):
         super(HODMD, self).__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank,
-            exact=exact, opt=opt, rescale_mode=rescale_mode)
+            exact=exact, opt=opt, rescale_mode=rescale_mode,
+            sorted_eigs=sorted_eigs)
         self._d = d
 
     @property

--- a/pydmd/optdmd.py
+++ b/pydmd/optdmd.py
@@ -53,7 +53,7 @@ class DMDOptOperator(DMDOperator):
 
     def __init__(self, svd_rank, factorization):
         super().__init__(svd_rank=svd_rank, exact=True,
-            forward_backward=False, rescale_mode=None)
+            forward_backward=False, rescale_mode=None, sorted_eigs=False)
         self._factorization = factorization
 
     @property

--- a/tests/test_cdmd.py
+++ b/tests/test_cdmd.py
@@ -227,3 +227,11 @@ class TestCDmd(TestCase):
         dmd.fit(X=sample_data)
         error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
         assert error_norm < 1e-10
+
+    def test_sorted_eigs_default(self):
+        dmd = CDMD(compression_matrix='sparse')
+        assert dmd.operator._sorted_eigs == False
+
+    def test_sorted_eigs_param(self):
+        dmd = CDMD(compression_matrix='sparse', sorted_eigs='real')
+        assert dmd.operator._sorted_eigs == 'real'

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -383,3 +383,146 @@ class TestDmd(TestCase):
 
         np.testing.assert_almost_equal(dmd2.reconstructed_data.real,
             dmd.reconstructed_data.real, decimal=6)
+
+
+    def test_sorted_eigs_default(self):
+        dmd = DMD()
+        assert dmd.operator._sorted_eigs == False
+
+    def test_sorted_eigs_set_real(self):
+        dmd = DMD(sorted_eigs='real')
+        assert dmd.operator._sorted_eigs == 'real'
+
+    def test_sorted_eigs_abs_right_eigs(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='abs')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        assert len(dmd.eigs) == len(dmd2.eigs)
+        assert set(dmd.eigs) == set(dmd2.eigs)
+
+        previous = dmd.eigs[0]
+        for eig in dmd.eigs[1:]:
+            assert abs(previous) <= abs(eig)
+            previous = eig
+
+    def test_sorted_eigs_abs_right_eigenvectors(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='abs')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            eigenvector = dmd2.operator.eigenvectors.T[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    assert all(dmd.operator.eigenvectors.T[idx_new] == eigenvector)
+                    break
+
+    def test_sorted_eigs_abs_right_modes(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='abs')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            mode = dmd2.modes.T[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    np.testing.assert_almost_equal(dmd.modes.T[idx_new], mode,
+                        decimal=6)
+                    break
+
+    def test_sorted_eigs_real_right_eigs(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='real')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        assert len(dmd.eigs) == len(dmd2.eigs)
+        assert set(dmd.eigs) == set(dmd2.eigs)
+
+        previous = complex(dmd.eigs[0])
+        for eig in dmd.eigs[1:]:
+            x = complex(eig)
+            assert x.real > previous.real or (x.real == previous.real and x.imag >= previous.imag)
+            previous = x
+
+    def test_sorted_eigs_real_right_eigenvectors(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='real')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            eigenvector = dmd2.operator.eigenvectors.T[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    assert all(dmd.operator.eigenvectors.T[idx_new] == eigenvector)
+                    break
+
+    def test_sorted_eigs_real_right_modes(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='real')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            mode = dmd2.modes.T[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    np.testing.assert_almost_equal(dmd.modes.T[idx_new], mode,
+                        decimal=6)
+                    break
+
+    def test_sorted_eigs_dynamics(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='abs')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            dynamic = dmd2.dynamics[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    np.testing.assert_almost_equal(dmd.dynamics[idx_new],
+                        dynamic, decimal=6)
+                    break
+
+    def test_sorted_eigs_frequency(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='abs')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            frq = dmd2.frequency[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    np.testing.assert_almost_equal(dmd.frequency[idx_new],
+                        frq, decimal=6)
+                    break
+
+    def test_sorted_eigs_amplitudes(self):
+        dmd = DMD(svd_rank=20, sorted_eigs='abs')
+        dmd.fit(sample_data)
+
+        dmd2 = DMD(svd_rank=20)
+        dmd2.fit(sample_data)
+
+        for idx, eig in enumerate(dmd2.eigs):
+            amp = dmd2.amplitudes[idx]
+            for idx_new, eig_new in enumerate(dmd.eigs):
+                if eig_new == eig:
+                    np.testing.assert_almost_equal(dmd.amplitudes[idx_new],
+                        amp, decimal=6)
+                    break

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -87,3 +87,11 @@ class TestDmdBase(TestCase):
         tpow = np.ndarray([0,1,2,3,5,6,7,11])
         for idx,x in enumerate(dmd._translate_eigs_exponent(tpow)):
             assert x == dmd._translate_eigs_exponent(tpow[idx])
+
+    def test_sorted_eigs_default(self):
+        dmd = DMDBase()
+        assert dmd.operator._sorted_eigs == False
+
+    def test_sorted_eigs_param(self):
+        dmd = DMDBase(sorted_eigs='real')
+        assert dmd.operator._sorted_eigs == 'real'

--- a/tests/test_dmdoperator.py
+++ b/tests/test_dmdoperator.py
@@ -17,7 +17,7 @@ sample_data = np.load('tests/test_datasets/input_sample.npy')
 class TestDmdOperator(TestCase):
     def test_constructor(self):
         operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode='auto')
+            rescale_mode='auto', sorted_eigs=False)
 
         assert operator._svd_rank == 2
         assert operator._exact == True
@@ -26,7 +26,7 @@ class TestDmdOperator(TestCase):
 
     def test_noncompute_error(self):
         operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode='auto')
+            rescale_mode='auto', sorted_eigs=False)
 
         with self.assertRaises(ValueError):
             operator.shape
@@ -48,7 +48,7 @@ class TestDmdOperator(TestCase):
 
     def test_compute_operator(self):
         operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode='auto')
+            rescale_mode='auto', sorted_eigs=False)
         operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
 
         assert operator.as_numpy_array is not None
@@ -61,14 +61,14 @@ class TestDmdOperator(TestCase):
     # values of X
     def test_rescalemode_auto_singular_values(self):
         operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode='auto')
+            rescale_mode='auto', sorted_eigs=False)
         operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
         np.testing.assert_almost_equal(operator._rescale_mode, np.array([3.]),
             decimal=1)
 
     def test_call(self):
         operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode=None)
+            rescale_mode=None, sorted_eigs=False)
 
         X = sample_data[:, :-1]
         Y = sample_data[:, 1:]
@@ -82,18 +82,18 @@ class TestDmdOperator(TestCase):
 
     def test_compute_eigenquantities_wrong_rescalemode(self):
         operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode=4)
+            rescale_mode=4, sorted_eigs=False)
         with self.assertRaises(ValueError):
             operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
 
         operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode=np.ones((4,)))
+            rescale_mode=np.ones((4,)), sorted_eigs=False)
         with self.assertRaises(ValueError):
             operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
 
     def test_plot_operator(self):
         operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode=None)
+            rescale_mode=None, sorted_eigs=False)
 
         X = sample_data[:, :-1]
         Y = sample_data[:, 1:]

--- a/tests/test_fbdmd.py
+++ b/tests/test_fbdmd.py
@@ -81,3 +81,11 @@ class TestFbDmd(TestCase):
         dmd.fit(X=sample_data)
         dmd.plot_eigs(show_axes=False, show_unit_circle=False)
         plt.close()
+
+    def test_sorted_eigs_default(self):
+        dmd = FbDMD(svd_rank=-1)
+        assert dmd.operator._sorted_eigs == False
+
+    def test_sorted_eigs_param(self):
+        dmd = FbDMD(svd_rank=-1, sorted_eigs='real')
+        assert dmd.operator._sorted_eigs == 'real'

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -258,3 +258,11 @@ class TestHODmd(TestCase):
         dmd.fit(X=sample_data)
         dmd.plot_eigs(show_axes=False, show_unit_circle=False)
         plt.close()
+
+    def test_sorted_eigs_default(self):
+        dmd = HODMD()
+        assert dmd.operator._sorted_eigs == False
+
+    def test_sorted_eigs_param(self):
+        dmd = HODMD(sorted_eigs='real')
+        assert dmd.operator._sorted_eigs == 'real'


### PR DESCRIPTION
This pull request addresses #163. I introduced the parameter `sorted_eigs` which takes the values `'real'`, `'abs'` or `False`.