### PR TITLE
Improve plot_eigs

### DIFF
--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -514,6 +514,47 @@ class DMDBase(object):
             return partial(DMDBase.ModesSelectors._integral_contribution, n=n)
 
 
+    def _enforce_ratio(self, goal_ratio, supx, infx, supy, infy):
+        """
+        Computes the right value of `supx,infx,supy,infy` to obtain the desired
+        ratio in :func:`plot_eigs`. Ratio is defined as
+        ::
+            dx = supx - infx
+            dy = supy - infy
+            max(dx,dy) / min(dx,dy)
+
+        :param float goal_ratio: the desired ratio.
+        :param float supx: the old value of `supx`, to be adjusted.
+        :param float infx: the old value of `infx`, to be adjusted.
+        :param float supy: the old value of `supy`, to be adjusted.
+        :param float infy: the old value of `infy`, to be adjusted.
+        :return tuple: a tuple which contains the updated values of
+            `supx,infx,supy,infy` in this order.
+        """
+
+        dx = supx - infx
+        if dx == 0:
+            dx = 1.e-16
+        dy = supy - infy
+        if dy == 0:
+            dy = 1.e-16
+        ratio = max(dx, dy) / min(dx, dy)
+
+        if ratio >= goal_ratio:
+            if dx < dy:
+                goal_size = dy / goal_ratio
+
+                supx += (goal_size - dx) / 2
+                infx -= (goal_size - dx) / 2
+            elif dy < dx:
+                goal_size = dx / goal_ratio
+
+                supy += (goal_size - dy) / 2
+                infy -= (goal_size - dy) / 2
+
+        return (supx,infx,supy,infy)
+
+
     def plot_eigs(self,
                   show_axes=True,
                   show_unit_circle=True,
@@ -562,14 +603,39 @@ class DMDBase(object):
             supy = max(self.eigs.imag) + 0.05
             infy = min(self.eigs.imag) - 0.05
 
+            supx, infx, supy, infy = self._enforce_ratio(8, supx, infx, supy,
+                infy)
+
             # set limits for axis
             ax.set_xlim((infx, supx))
             ax.set_ylim((infy, supy))
+
+            # x and y axes
+            if show_axes:
+                ax.annotate('',
+                            xy=(np.min([supx, 1.]), 0.),
+                            xytext=(np.max([infx, -1.]), 0.),
+                            arrowprops=dict(arrowstyle="->"))
+                ax.annotate('',
+                            xy=(0., np.min([supy, 1.])),
+                            xytext=(0., np.max([infy, -1.])),
+                            arrowprops=dict(arrowstyle="->"))
         else:
             # set limits for axis
             limit = np.max(np.ceil(np.absolute(self.eigs)))
             ax.set_xlim((-limit, limit))
             ax.set_ylim((-limit, limit))
+
+            # x and y axes
+            if show_axes:
+                ax.annotate('',
+                            xy=(np.max([limit * 0.8, 1.]), 0.),
+                            xytext=(np.min([-limit * 0.8, -1.]), 0.),
+                            arrowprops=dict(arrowstyle="->"))
+                ax.annotate('',
+                            xy=(0., np.max([limit * 0.8, 1.])),
+                            xytext=(0., np.min([-limit * 0.8, -1.])),
+                            arrowprops=dict(arrowstyle="->"))
 
         plt.ylabel('Imaginary part')
         plt.xlabel('Real part')
@@ -589,25 +655,14 @@ class DMDBase(object):
             line.set_linestyle('-.')
         ax.grid(True)
 
-        # x and y axes
-        if show_axes:
-            ax.annotate('',
-                        xy=(np.max([limit * 0.8, 1.]), 0.),
-                        xytext=(np.min([-limit * 0.8, -1.]), 0.),
-                        arrowprops=dict(arrowstyle="->"))
-            ax.annotate('',
-                        xy=(0., np.max([limit * 0.8, 1.])),
-                        xytext=(0., np.min([-limit * 0.8, -1.])),
-                        arrowprops=dict(arrowstyle="->"))
-
         # legend
         if show_unit_circle:
             ax.add_artist(
                 plt.legend([points, unit_circle],
                            ['Eigenvalues', 'Unit circle'],
-                           loc=1))
+                           loc='best'))
         else:
-            ax.add_artist(plt.legend([points], ['Eigenvalues'], loc=1))
+            ax.add_artist(plt.legend([points], ['Eigenvalues'], loc='best'))
 
         ax.set_aspect('equal')
 

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -555,6 +555,20 @@ class DMDBase(object):
         return (supx,infx,supy,infy)
 
 
+    def _plot_limits(self, narrow_view):
+        if narrow_view:
+            supx = max(self.eigs.real) + 0.05
+            infx = min(self.eigs.real) - 0.05
+
+            supy = max(self.eigs.imag) + 0.05
+            infy = min(self.eigs.imag) - 0.05
+
+            return self._enforce_ratio(8, supx, infx, supy,
+                infy)
+        else:
+            return np.max(np.ceil(np.absolute(self.eigs)))
+
+
     def plot_eigs(self,
                   show_axes=True,
                   show_unit_circle=True,
@@ -597,14 +611,7 @@ class DMDBase(object):
                           label='Eigenvalues')
 
         if narrow_view:
-            supx = max(self.eigs.real) + 0.05
-            infx = min(self.eigs.real) - 0.05
-
-            supy = max(self.eigs.imag) + 0.05
-            infy = min(self.eigs.imag) - 0.05
-
-            supx, infx, supy, infy = self._enforce_ratio(8, supx, infx, supy,
-                infy)
+            supx, infx, supy, infy = self._plot_limits(narrow_view)
 
             # set limits for axis
             ax.set_xlim((infx, supx))
@@ -622,7 +629,8 @@ class DMDBase(object):
                             arrowprops=dict(arrowstyle="->"))
         else:
             # set limits for axis
-            limit = np.max(np.ceil(np.absolute(self.eigs)))
+            limit = self._plot_limits(narrow_view)
+
             ax.set_xlim((-limit, limit))
             ax.set_ylim((-limit, limit))
 

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -619,14 +619,17 @@ class DMDBase(object):
 
             # x and y axes
             if show_axes:
+                endx = np.min([supx, 1.])
                 ax.annotate('',
-                            xy=(np.min([supx, 1.]), 0.),
+                            xy=(endx, 0.),
                             xytext=(np.max([infx, -1.]), 0.),
-                            arrowprops=dict(arrowstyle="->"))
+                            arrowprops=dict(arrowstyle=("->" if endx == 1. else '-')))
+
+                endy = np.min([supy, 1.])
                 ax.annotate('',
-                            xy=(0., np.min([supy, 1.])),
+                            xy=(0., endy),
                             xytext=(0., np.max([infy, -1.])),
-                            arrowprops=dict(arrowstyle="->"))
+                            arrowprops=dict(arrowstyle=("->" if endy == 1. else '-')))
         else:
             # set limits for axis
             limit = self._plot_limits(narrow_view)

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -153,3 +153,19 @@ class TestDmdBase(TestCase):
         exp = dmd.reconstructed_data
         dmd.select_modes(DMDBase.ModesSelectors.integral_contribution(2))
         np.testing.assert_array_almost_equal(exp, dmd.reconstructed_data)
+
+    def test_enforce_ratio_y(self):
+        dmd = DMDBase()
+        supx, infx, supy, infy = dmd._enforce_ratio(10, 20, 10, 0, 0)
+
+        dx = supx - infx
+        dy = supy - infy
+        np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)
+
+    def test_enforce_ratio_x(self):
+        dmd = DMDBase()
+        supx, infx, supy, infy = dmd._enforce_ratio(10, 0, 0, 20, 10)
+
+        dx = supx - infx
+        dy = supy - infy
+        np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -169,3 +169,25 @@ class TestDmdBase(TestCase):
         dx = supx - infx
         dy = supy - infy
         np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)
+
+
+    def test_plot_limits_narrow(self):
+        dmd = DMDBase()
+        dmd.operator._eigenvalues = np.array([complex(1,2), complex(-1,-2)])
+
+        tp = dmd._plot_limits(True)
+
+        assert len(tp) == 4
+
+        supx, infx, supy, infy = tp
+        assert supx == 1.05
+        assert infx == -1.05
+        assert supy == 2.05
+        assert infy == -2.05
+
+    def test_plot_limits(self):
+        dmd = DMDBase()
+        dmd.operator._eigenvalues = np.array([complex(-2,2), complex(3,-3)])
+
+        limit = dmd._plot_limits(False)
+        assert limit == 5


### PR DESCRIPTION
In this pull request I introduce some changes to improve `DMDBase.plot_eigs`:
- `narrow_view` is now compatible with `show_axes=True` (you can see the result in the attached image);
- the ratio of the resulting image induced by `narrow_view` must be lower than 8 (to fix the fact that when, for instance, all the eigenvalues have the same complex part, the image degenerates to an horizontal line);
- `plt.legend(..., loc='best')` instead of `loc='1', which places the legend in the optimal place to reduce the overlap with the plot (instead of placing it always on the top right), the attached image demonstrates the behavior.

![image](https://user-images.githubusercontent.com/8464342/116220346-e1a56c80-a74c-11eb-8e4d-a08902568972.png)
