### PR TITLE
Fixed problem in HODMD

### DIFF
--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -290,11 +290,16 @@ class TestHODmd(TestCase):
     def test_nonan_nomask(self):
         dmd = HODMD(d=3)
         dmd.fit(X=sample_data)
+        rec = dmd.reconstructed_data
+
+        assert not isinstance(rec, np.ma.MaskedArray)
+        assert not np.nan in rec
+
+    def test_extract_versions_nonan(self):
+        dmd = HODMD(d=3)
+        dmd.fit(X=sample_data)
         for timeindex in range(sample_data.shape[1]):
-            ds = dmd.reconstructions_of_timeindex(timeindex)
-            for mx in ds:
-                assert not np.ma.is_masked(mx)
-                assert np.nan not in mx
+            assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
 
     def test_rec_method_first(self):
         dmd = HODMD(d=3, reconstruction_method='first')


### PR DESCRIPTION
- Fixed a problem in `HODMD` which disallowed saving `HODMD.reconstructed_data` with `np.load` (since `HODMD.reconstructed_data` was an instance of `np.ma.MaskedArray`, even though there weren't masked values);
- `HODMD.reconstructions_of_timeindex` now starts saving snapshots from the first index of `reconstructed_snapshots[time_idx]`;
- Documentation for `HODMD.reconstructions_of_timeindex`;
- Since we use`np.ma.MaskedArray`, I added some tests to check that no array of this kind "escapes" to reach the user.