### PR TITLE
Fix shape problems in fbdmd

### DIFF
--- a/pydmd/dmdoperator.py
+++ b/pydmd/dmdoperator.py
@@ -58,7 +58,7 @@ class DMDOperator(object):
 
         if self._forward_backward:
             # b stands for "backward"
-            bU, bs, bV = self._compute_svd(Y, svd_rank=self._svd_rank)
+            bU, bs, bV = self._compute_svd(Y, svd_rank=len(s))
             atilde_back = self._least_square_operator(bU, bs, bV, X)
             atilde = sqrtm(atilde.dot(np.linalg.inv(atilde_back)))
 


### PR DESCRIPTION
When using an automatic rank for `svd_rank`, and `forward_backward=True`, it may happen that the number of singular values taken for `X` and `Y` is different. This leads to shape problems in the subsequent steps.

In this commit we enforce taking for `Y` the same number of singular values taken for `X`.