### PR TITLE
Restricted key set for DMDBase.dmd_time

### DIFF
--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.sparse
 from scipy.linalg import sqrtm
 
-from .dmdbase import DMDBase
+from .dmdbase import DMDBase, DMDTimeDict
 from .dmdoperator import DMDOperator
 
 from .utils import compute_tlsq
@@ -195,8 +195,8 @@ class CDMD(DMDBase):
         U, s, V = self.operator.compute_operator(X,Y, self._snapshots[:, 1:])
 
         # Default timesteps
-        self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
-        self.dmd_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
+        self.original_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
 
         self._b = self._compute_amplitudes()
 

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -6,7 +6,7 @@ Derived module from dmdbase.py for classic dmd.
 import numpy as np
 
 # --> Import PyDMD base class for DMD.
-from .dmdbase import DMDBase
+from .dmdbase import DMDBase, DMDTimeDict
 
 from .dmdoperator import DMDOperator
 from .utils import compute_tlsq
@@ -64,8 +64,8 @@ class DMD(DMDBase):
         self._svd_modes, _, _ = self.operator.compute_operator(X,Y)
 
         # Default timesteps
-        self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
-        self.dmd_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
+        self.original_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
 
         self._b = self._compute_amplitudes()
 

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -864,3 +864,10 @@ class DMDBase(object):
 
         if not filename:
             plt.show()
+
+class DMDTimeDict(dict):
+    def __setitem__(self, key, value):
+        if key in ['t0', 'tend', 'dt']:
+            dict.__setitem__(self, key, value)
+        else:
+            raise KeyError('DMDBase.dmd_time accepts only the following keys: "t0", "tend", "dt", {} is not allowed.'.format(key))

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -8,7 +8,7 @@ with control. SIAM Journal on Applied Dynamical Systems, 15(1), pp.142-161.
 from past.utils import old_div
 import numpy as np
 
-from .dmdbase import DMDBase
+from .dmdbase import DMDBase, DMDTimeDict
 from .dmdoperator import DMDOperator
 from .utils import compute_tlsq
 
@@ -271,8 +271,8 @@ class DMDc(DMDBase):
         X = self._snapshots[:, :-1]
         Y = self._snapshots[:, 1:]
 
-        self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
-        self.dmd_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
+        self.original_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
 
         if B is None:
             self._Atilde = DMDBUnknownOperator(**self._dmd_operator_kwargs)

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -7,7 +7,7 @@ Journal on Applied Dynamical Systems, 16(2), 882-925, 2017.
 """
 import numpy as np
 
-from .dmdbase import DMDBase
+from .dmdbase import DMDBase, DMDTimeDict
 from .utils import compute_tlsq
 
 
@@ -154,8 +154,8 @@ class HODMD(DMDBase):
         U, s, V = self.operator.compute_operator(X,Y)
 
         # Default timesteps
-        self.original_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
-        self.dmd_time = {'t0': 0, 'tend': n_samples - 1, 'dt': 1}
+        self.original_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
 
         self._b = self._compute_amplitudes()
 

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -13,7 +13,7 @@ import scipy.linalg
 import matplotlib.pyplot as plt
 from copy import deepcopy
 
-from .dmdbase import DMDBase
+from .dmdbase import DMDBase, DMDTimeDict
 
 class BinaryTree(object):
 
@@ -418,8 +418,10 @@ class MrDMD(DMDBase):
             X -= newX
 
 
-        self._dmd_time = dict(t0 = 0, tend = self._snapshots.shape[1], dt= 1)
-        self._original_time = self.dmd_time.copy()
+        self._dmd_time = DMDTimeDict(
+            dict(t0 = 0, tend = self._snapshots.shape[1], dt= 1))
+        self._original_time = DMDTimeDict(
+            dict(t0 = 0, tend = self._snapshots.shape[1], dt= 1))
 
         return self
 

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -191,3 +191,10 @@ class TestDmdBase(TestCase):
 
         limit = dmd._plot_limits(False)
         assert limit == 5
+
+    def test_dmd_time_wrong_key(self):
+        dmd = DMD(svd_rank=10)
+        dmd.fit(sample_data)
+
+        with self.assertRaises(KeyError):
+            dmd.dmd_time['tstart'] = 10


### PR DESCRIPTION
I recognized that the shape of the output of `reconstructed_data` in one of my script was not as expected, comparing it with the time instants which I requested using `dmd_time`.

I checked what was inside `dmd_time` and I found that I set `tstart` instead of `t0`.

In this commit I introduced a custom subclass of `dict` to avoid this problem. The subclass accepts only keys in `['t0', 'tend', 'dt']`, and raises `KeyError` otherwise.