### PR TITLE
HankelDMD uses an auxiliary DMD instance to preserve timesteps

### DIFF
--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from .dmdbase import DMDBase, DMDTimeDict
 from .utils import compute_tlsq
+from .dmd import DMD
 
 
 class HankelDMD(DMDBase):
@@ -54,25 +55,74 @@ class HankelDMD(DMDBase):
     :type reconstruction_method: {'first', 'mean'} or array-like
     """
 
-    def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-        rescale_mode=None, forward_backward=False, d=1, sorted_eigs=False,
-        reconstruction_method='first'):
-        super().__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank,
-            exact=exact, opt=opt, rescale_mode=rescale_mode,
-            sorted_eigs=sorted_eigs)
+    def __init__(
+        self,
+        svd_rank=0,
+        tlsq_rank=0,
+        exact=False,
+        opt=False,
+        rescale_mode=None,
+        forward_backward=False,
+        d=1,
+        sorted_eigs=False,
+        reconstruction_method="first",
+    ):
+        super().__init__(
+            svd_rank=svd_rank,
+            tlsq_rank=tlsq_rank,
+            exact=exact,
+            opt=opt,
+            rescale_mode=rescale_mode,
+            sorted_eigs=sorted_eigs,
+        )
         self._d = d
 
         if isinstance(reconstruction_method, list):
             if len(reconstruction_method) != d:
-                raise ValueError('The length of the array of weights must be equal to d')
+                raise ValueError(
+                    "The length of the array of weights must be equal to d"
+                )
         elif isinstance(reconstruction_method, np.ndarray):
-            if reconstruction_method.ndim > 1 or reconstruction_method.shape[0] != d:
-                raise ValueError('The length of the array of weights must be equal to d')
+            if (
+                reconstruction_method.ndim > 1
+                or reconstruction_method.shape[0] != d
+            ):
+                raise ValueError(
+                    "The length of the array of weights must be equal to d"
+                )
         self._reconstruction_method = reconstruction_method
+
+        self._sub_dmd = DMD(
+            svd_rank=svd_rank,
+            tlsq_rank=tlsq_rank,
+            exact=exact,
+            opt=opt,
+            rescale_mode=rescale_mode,
+            forward_backward=forward_backward,
+            sorted_eigs=sorted_eigs,
+        )
 
     @property
     def d(self):
         return self._d
+
+    def _hankel_first_occurrence(self, time, is_original_t0=False):
+        if is_original_t0:
+            return 0
+        else:
+            return max(
+                0,
+                (time - self.original_time["t0"]) // self.dmd_time["dt"]
+                - (self.original_time["t0"] + self.d - 1),
+            )
+
+    def _update_sub_dmd_time(self):
+        self._sub_dmd.dmd_time["t0"] = self._hankel_first_occurrence(
+            self.dmd_time["t0"]
+        )
+        self._sub_dmd.dmd_time["tend"] = self._hankel_first_occurrence(
+            self.dmd_time["tend"]
+        )
 
     def reconstructions_of_timeindex(self, timeindex=None):
         """
@@ -89,7 +139,9 @@ class HankelDMD(DMDBase):
             of the array returned).
         :rtype: numpy.ndarray or list
         """
-        rec = super().reconstructed_data
+        self._update_sub_dmd_time()
+
+        rec = self._sub_dmd.reconstructed_data
         space_dim = rec.shape[0] // self.d
         time_instants = rec.shape[1] + self.d - 1
 
@@ -97,7 +149,8 @@ class HankelDMD(DMDBase):
         # each snapshot appears at most d times (for instance, the first and
         # the last appear only once).
         reconstructed_snapshots = np.full(
-            (time_instants, self.d, space_dim), np.nan, dtype=np.complex128)
+            (time_instants, self.d, space_dim), np.nan, dtype=np.complex128
+        )
 
         first_empty = np.zeros((time_instants,), dtype=np.int8)
 
@@ -113,24 +166,31 @@ class HankelDMD(DMDBase):
         if timeindex is None:
             return reconstructed_snapshots
         else:
-            return reconstructed_snapshots[timeindex][:first_empty[timeindex]]
+            return reconstructed_snapshots[timeindex][: first_empty[timeindex]]
 
     @property
     def reconstructed_data(self):
+        self._update_sub_dmd_time()
+
         rec = self.reconstructions_of_timeindex()
         rec = np.ma.array(rec, mask=np.isnan(rec))
 
-        if self._reconstruction_method == 'first':
-            result = rec[:,0].T
-        elif self._reconstruction_method == 'mean':
+        if self._reconstruction_method == "first":
+            result = rec[:, 0].T
+        elif self._reconstruction_method == "mean":
             result = np.mean(rec, axis=1).T
-        elif (isinstance(self._reconstruction_method, list) or
-            isinstance(self._reconstruction_method, np.ndarray)):
-            result = np.average(rec, axis=1,
-                                weights=self._reconstruction_method).T
+        elif isinstance(self._reconstruction_method, list) or isinstance(
+            self._reconstruction_method, np.ndarray
+        ):
+            result = np.average(
+                rec, axis=1, weights=self._reconstruction_method
+            ).T
         else:
-            raise ValueError("The reconstruction method wasn't recognized: {}"
-                .format(self._reconstruction_method))
+            raise ValueError(
+                "The reconstruction method wasn't recognized: {}".format(
+                    self._reconstruction_method
+                )
+            )
 
         return result.filled(fill_value=0)
 
@@ -155,11 +215,25 @@ class HankelDMD(DMDBase):
 
         """
         return np.concatenate(
-            [
-                X[:, i:X.shape[1] - self.d + i + 1]
-                for i in range(self.d)
-            ],
-            axis=0)
+            [X[:, i : X.shape[1] - self.d + i + 1] for i in range(self.d)],
+            axis=0,
+        )
+
+    @property
+    def modes(self):
+        return self._sub_dmd.modes
+
+    @property
+    def amplitudes(self):
+        return self._sub_dmd.amplitudes
+
+    @property
+    def operator(self):
+        return self._sub_dmd.operator
+
+    @property
+    def svd_rank(self):
+        return self._sub_dmd.svd_rank
 
     def fit(self, X):
         """
@@ -170,18 +244,13 @@ class HankelDMD(DMDBase):
         """
         snp, self._snapshots_shape = self._col_major_2darray(X)
         self._snapshots = self._pseudo_hankel_matrix(snp)
-
-        n_samples = self._snapshots.shape[1]
-        X = self._snapshots[:, :-1]
-        Y = self._snapshots[:, 1:]
-
-        X, Y = compute_tlsq(X, Y, self.tlsq_rank)
-        U, s, V = self.operator.compute_operator(X,Y)
+        self._sub_dmd.fit(self._snapshots)
 
         # Default timesteps
-        self.original_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
-        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
-
-        self._b = self._compute_amplitudes()
+        n_samples = snp.shape[1]
+        self.original_time = DMDTimeDict(
+            {"t0": 0, "tend": n_samples - 1, "dt": 1}
+        )
+        self.dmd_time = DMDTimeDict({"t0": 0, "tend": n_samples - 1, "dt": 1})
 
         return self

--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -138,13 +138,6 @@ class HankelDMD(DMDBase):
             self.dmd_time["tend"]
         )
 
-        self._sub_dmd.original_time["t0"] = self._hankel_first_occurrence(
-            self.original_time["t0"]
-        )
-        self._sub_dmd.original_time["tend"] = self._hankel_first_occurrence(
-            self.original_time["tend"]
-        )
-
     def reconstructions_of_timeindex(self, timeindex=None):
         """
         Build a collection of all the available versions of the given
@@ -212,6 +205,16 @@ class HankelDMD(DMDBase):
                     self._reconstruction_method
                 )
             )
+
+        # we want to return only the requested timesteps
+        time_index = min(
+            self.d - 1,
+            int(
+                (self.dmd_time["t0"] - self.original_time["t0"])
+                // self.dmd_time["dt"]
+            ),
+        )
+        result = result[:, time_index : time_index + len(self.dmd_timesteps)]
 
         return result.filled(fill_value=0)
 

--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -106,22 +106,43 @@ class HankelDMD(DMDBase):
     def d(self):
         return self._d
 
-    def _hankel_first_occurrence(self, time, is_original_t0=False):
-        if is_original_t0:
-            return 0
-        else:
-            return max(
-                0,
-                (time - self.original_time["t0"]) // self.dmd_time["dt"]
-                - (self.original_time["t0"] + self.d - 1),
-            )
+    def _hankel_first_occurrence(self, time):
+        """
+        For a given `t` such that there is :math:`k \in \mathbb{N}` such that
+        :math:`t = t_0 + k dt`, return the index of the first column in Hankel
+        pseudo matrix (see also :func:`_pseudo_hankel_matrix`) which contains
+        the snapshot corresponding to `t`.
+
+        :param time: The time corresponding to the requested snapshot.
+        :return: The index of the first appeareance of `time` in the columns of
+            Hankel pseudo matrix.
+        :rtype: int
+        """
+        return max(
+            0,
+            (time - self.original_time["t0"]) // self.dmd_time["dt"]
+            - (self.original_time["t0"] + self.d - 1),
+        )
 
     def _update_sub_dmd_time(self):
+        """
+        Update the time dictionaries (`dmd_time` and `original_time`) of
+        the auxiliary DMD instance `HankelDMD._sub_dmd` after an update of the
+        time dictionaries of the time dictionaries of this instance of the
+        higher level instance of `HankelDMD`.
+        """
         self._sub_dmd.dmd_time["t0"] = self._hankel_first_occurrence(
             self.dmd_time["t0"]
         )
         self._sub_dmd.dmd_time["tend"] = self._hankel_first_occurrence(
             self.dmd_time["tend"]
+        )
+
+        self._sub_dmd.original_time["t0"] = self._hankel_first_occurrence(
+            self.original_time["t0"]
+        )
+        self._sub_dmd.original_time["tend"] = self._hankel_first_occurrence(
+            self.original_time["tend"]
         )
 
     def reconstructions_of_timeindex(self, timeindex=None):

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -136,7 +136,8 @@ class HODMD(HankelDMD):
         if org_snp.shape[0] == 1:
             self.U_extra, _, _ = compute_svd(org_snp, -1)
             warnings.warn(
-                "The parameter 'svd_rank_extra={}' has been ignored because the given system is a scalar function".format(
+                """The parameter 'svd_rank_extra={}' has been ignored because
+the given system is a scalar function""".format(
                     self.svd_rank_extra
                 )
             )

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -122,3 +122,5 @@ class HODMD(HankelDMD):
         super().fit(snp)
         self._snapshots_shape = snapshots_shape
         self._snapshots = org_snp
+
+        return self

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -7,6 +7,8 @@ Journal on Applied Dynamical Systems, 16(2), 882-925, 2017.
 """
 import numpy as np
 
+import warnings
+
 from .hankeldmd import HankelDMD
 from .utils import compute_tlsq, compute_svd
 
@@ -62,15 +64,30 @@ class HODMD(HankelDMD):
     :type svd_rank: int or float
     """
 
-    def __init__(self, svd_rank=0, tlsq_rank=0, exact=False, opt=False,
-                 rescale_mode=None, forward_backward=False, d=1,
-                 sorted_eigs=False, reconstruction_method='first',
-                 svd_rank_extra=0):
-        super().__init__(svd_rank=svd_rank, tlsq_rank=tlsq_rank, exact=exact,
-                         opt=opt, rescale_mode=rescale_mode,
-                         forward_backward=forward_backward, d=d,
-                         sorted_eigs=sorted_eigs,
-                         reconstruction_method=reconstruction_method)
+    def __init__(
+        self,
+        svd_rank=0,
+        tlsq_rank=0,
+        exact=False,
+        opt=False,
+        rescale_mode=None,
+        forward_backward=False,
+        d=1,
+        sorted_eigs=False,
+        reconstruction_method="first",
+        svd_rank_extra=0,
+    ):
+        super().__init__(
+            svd_rank=svd_rank,
+            tlsq_rank=tlsq_rank,
+            exact=exact,
+            opt=opt,
+            rescale_mode=rescale_mode,
+            forward_backward=forward_backward,
+            d=d,
+            sorted_eigs=sorted_eigs,
+            reconstruction_method=reconstruction_method,
+        )
 
         self.svd_rank_extra = svd_rank_extra  # TODO improve names
         self.U_extra = None
@@ -98,9 +115,9 @@ class HODMD(HankelDMD):
         if snapshots.ndim == 2:  # single time instant
             snapshots = self.U_extra.dot(snapshots.T).T
         elif snapshots.ndim == 3:  # all time instants
-            snapshots = np.array([
-                self.U_extra.dot(snapshot.T).T
-                for snapshot in snapshots])
+            snapshots = np.array(
+                [self.U_extra.dot(snapshot.T).T for snapshot in snapshots]
+            )
         else:
             raise RuntimeError
 
@@ -116,7 +133,16 @@ class HODMD(HankelDMD):
         """
         org_snp, snapshots_shape = self._col_major_2darray(X)
 
-        self.U_extra, _, _ = compute_svd(org_snp, self.svd_rank_extra)
+        if org_snp.shape[0] == 1:
+            self.U_extra, _, _ = compute_svd(org_snp, -1)
+            warnings.warn(
+                "The parameter 'svd_rank_extra={}' has been ignored because the given system is a scalar function".format(
+                    self.svd_rank_extra
+                )
+            )
+        else:
+            self.U_extra, _, _ = compute_svd(org_snp, self.svd_rank_extra)
+
         snp = self.U_extra.T.dot(org_snp)
 
         super().fit(snp)

--- a/tests/test_hankeldmd.py
+++ b/tests/test_hankeldmd.py
@@ -9,19 +9,19 @@ import os
 # the following data: f1 + f2 where
 # f1 = lambda x,t: sech(x+3)*(1.*np.exp(1j*2.3*t))
 # f2 = lambda x,t: (sech(x)*np.tanh(x))*(2.*np.exp(1j*2.8*t))
-sample_data = np.load('tests/test_datasets/input_sample.npy')
+sample_data = np.load("tests/test_datasets/input_sample.npy")
 
 
 def create_noisy_data():
-    mu = 0.
-    sigma = 0.  # noise standard deviation
+    mu = 0.0
+    sigma = 0.0  # noise standard deviation
     m = 100  # number of snapshot
     noise = np.random.normal(mu, sigma, m)  # gaussian noise
-    A = np.array([[1., 1.], [-1., 2.]])
+    A = np.array([[1.0, 1.0], [-1.0, 2.0]])
     A /= np.sqrt(3)
     n = 2
     X = np.zeros((n, m))
-    X[:, 0] = np.array([0.5, 1.])
+    X[:, 0] = np.array([0.5, 1.0])
     # evolve the system and perturb the data with noise
     for k in range(1, m):
         X[:, k] = A.dot(X[:, k - 1])
@@ -32,7 +32,7 @@ def create_noisy_data():
 noisy_data = create_noisy_data()
 
 
-class TestHODmd(TestCase):
+class TestHankelDmd(TestCase):
     def test_shape(self):
         dmd = HankelDMD(svd_rank=-1)
         dmd.fit(X=sample_data)
@@ -57,14 +57,17 @@ class TestHODmd(TestCase):
         single_data = np.sin(np.linspace(0, 10, 100))
         dmd = HankelDMD(svd_rank=-1, d=50, opt=True)
         dmd.fit(single_data)
-        assert np.allclose(dmd.reconstructed_data.flatten(), single_data)
+        assert np.allclose(dmd.reconstructed_data.flatten().real, single_data)
 
     def test_Atilde_values(self):
         dmd = HankelDMD(svd_rank=2)
         dmd.fit(X=sample_data)
         exact_atilde = np.array(
-            [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
-             [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
+            [
+                [-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
+                [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j],
+            ]
+        )
         np.testing.assert_allclose(exact_atilde, dmd.atilde)
 
     def test_eigs_1(self):
@@ -80,9 +83,12 @@ class TestHODmd(TestCase):
     def test_eigs_3(self):
         dmd = HankelDMD(svd_rank=2)
         dmd.fit(X=sample_data)
-        expected_eigs = np.array([
-            -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
-        ])
+        expected_eigs = np.array(
+            [
+                -8.09016994e-01 + 5.87785252e-01j,
+                -4.73868662e-01 + 8.80595532e-01j,
+            ]
+        )
         np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
 
     def test_dynamics_1(self):
@@ -93,16 +99,27 @@ class TestHODmd(TestCase):
     def test_dynamics_2(self):
         dmd = HankelDMD(svd_rank=1)
         dmd.fit(X=sample_data)
-        expected_dynamics = np.array([[
-            -2.20639502 - 9.10168802e-16j, 1.55679980 - 1.49626864e+00j,
-            -0.08375915 + 2.11149018e+00j, -1.37280962 - 1.54663768e+00j,
-            2.01748787 + 1.60312745e-01j, -1.53222592 + 1.25504678e+00j,
-            0.23000498 - 1.92462280e+00j, 1.14289644 + 1.51396355e+00j,
-            -1.83310653 - 2.93174173e-01j, 1.49222925 - 1.03626336e+00j,
-            -0.35015209 + 1.74312867e+00j, -0.93504202 - 1.46738182e+00j,
-            1.65485808 + 4.01263449e-01j, -1.43976061 + 8.39117825e-01j,
-            0.44682540 - 1.56844403e+00j
-        ]])
+        expected_dynamics = np.array(
+            [
+                [
+                    -2.20639502 - 9.10168802e-16j,
+                    1.55679980 - 1.49626864e00j,
+                    -0.08375915 + 2.11149018e00j,
+                    -1.37280962 - 1.54663768e00j,
+                    2.01748787 + 1.60312745e-01j,
+                    -1.53222592 + 1.25504678e00j,
+                    0.23000498 - 1.92462280e00j,
+                    1.14289644 + 1.51396355e00j,
+                    -1.83310653 - 2.93174173e-01j,
+                    1.49222925 - 1.03626336e00j,
+                    -0.35015209 + 1.74312867e00j,
+                    -0.93504202 - 1.46738182e00j,
+                    1.65485808 + 4.01263449e-01j,
+                    -1.43976061 + 8.39117825e-01j,
+                    0.44682540 - 1.56844403e00j,
+                ]
+            ]
+        )
         np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
 
     def test_dynamics_opt_1(self):
@@ -113,16 +130,27 @@ class TestHODmd(TestCase):
     def test_dynamics_opt_2(self):
         dmd = HankelDMD(svd_rank=1, opt=True)
         dmd.fit(X=sample_data)
-        expected_dynamics = np.array([[
-            -4.56004133 - 6.48054238j, 7.61228319 + 1.4801793j,
-            -6.37489962 + 4.11788355j, 1.70548899 - 7.22866146j,
-            3.69875496 + 6.25701574j, -6.85298745 - 1.90654427j,
-            6.12829151 - 3.30212967j, -2.08469012 + 6.48584004j,
-            -2.92745126 - 5.99004747j, 6.12772217 + 2.24123565j,
-            -5.84352626 + 2.57413711j, 2.37745273 - 5.77906544j,
-            2.24158249 + 5.68989493j, -5.44023459 - 2.49457492j,
-            5.53024740 - 1.92916437j
-        ]])
+        expected_dynamics = np.array(
+            [
+                [
+                    -4.56004133 - 6.48054238j,
+                    7.61228319 + 1.4801793j,
+                    -6.37489962 + 4.11788355j,
+                    1.70548899 - 7.22866146j,
+                    3.69875496 + 6.25701574j,
+                    -6.85298745 - 1.90654427j,
+                    6.12829151 - 3.30212967j,
+                    -2.08469012 + 6.48584004j,
+                    -2.92745126 - 5.99004747j,
+                    6.12772217 + 2.24123565j,
+                    -5.84352626 + 2.57413711j,
+                    2.37745273 - 5.77906544j,
+                    2.24158249 + 5.68989493j,
+                    -5.44023459 - 2.49457492j,
+                    5.53024740 - 1.92916437j,
+                ]
+            ]
+        )
         np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
 
     def test_reconstructed_data(self):
@@ -134,46 +162,64 @@ class TestHODmd(TestCase):
     def test_original_time(self):
         dmd = HankelDMD(svd_rank=2)
         dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+        expected_dict = {"dt": 1, "t0": 0, "tend": 14}
         np.testing.assert_equal(dmd.original_time, expected_dict)
 
     def test_original_timesteps(self):
         dmd = HankelDMD()
         dmd.fit(X=sample_data)
-        np.testing.assert_allclose(dmd.original_timesteps,
-                                   np.arange(sample_data.shape[1]))
+        np.testing.assert_allclose(
+            dmd.original_timesteps, np.arange(sample_data.shape[1])
+        )
 
     def test_dmd_time_1(self):
         dmd = HankelDMD(svd_rank=2)
         dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+        expected_dict = {"dt": 1, "t0": 0, "tend": 14}
         np.testing.assert_equal(dmd.dmd_time, expected_dict)
 
     def test_dmd_time_2(self):
         dmd = HankelDMD()
         dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 10
-        dmd.dmd_time['tend'] = 14
+        dmd.dmd_time["t0"] = 10
+        dmd.dmd_time["tend"] = 14
         expected_data = sample_data[:, -5:]
         np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
     def test_dmd_time_3(self):
         dmd = HankelDMD()
         dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 8
-        dmd.dmd_time['tend'] = 11
+        dmd.dmd_time["t0"] = 8
+        dmd.dmd_time["tend"] = 11
         expected_data = sample_data[:, 8:12]
         np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
     def test_dmd_time_4(self):
         dmd = HankelDMD(svd_rank=3)
         dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 20
-        dmd.dmd_time['tend'] = 20
-        expected_data = np.array([[-7.29383297e+00 - 4.90248179e-14j],
-                                  [-5.69109796e+00 - 2.74068833e+00j],
-                                  [3.38410649e-83 + 3.75677740e-83j]])
+        dmd.dmd_time["t0"] = 20
+        dmd.dmd_time["tend"] = 20
+        expected_data = np.array(
+            [
+                [-7.29383297e00 - 4.90248179e-14j],
+                [-5.69109796e00 - 2.74068833e00j],
+                [3.38410649e-83 + 3.75677740e-83j],
+            ]
+        )
         np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
+
+    def test_dmd_time_5(self):
+        x = np.linspace(0, 10, 64)
+        y = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+
+        dmd = HankelDMD(svd_rank=-1, exact=True, opt=True, d=30)
+        dmd.fit(y)
+
+        dmd.original_time["dt"] = dmd.dmd_time["dt"] = x[1] - x[0]
+        dmd.original_time["t0"] = dmd.dmd_time["t0"] = x[0]
+        dmd.original_time["tend"] = dmd.dmd_time["tend"] = x[-1]
+
+        assert dmd.reconstructed_data.shape == (1, 64)
 
     def test_plot_eigs_1(self):
         dmd = HankelDMD()
@@ -217,8 +263,8 @@ class TestHODmd(TestCase):
         dmd = HankelDMD()
         snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
         dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.1.png')
+        dmd.plot_modes_2D(index_mode=1, filename="tmp.png")
+        self.addCleanup(os.remove, "tmp.1.png")
 
     def test_plot_snapshots_1(self):
         dmd = HankelDMD()
@@ -250,8 +296,8 @@ class TestHODmd(TestCase):
         dmd = HankelDMD()
         snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
         dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.2.png')
+        dmd.plot_snapshots_2D(index_snap=2, filename="tmp.png")
+        self.addCleanup(os.remove, "tmp.2.png")
 
     def test_tdmd_plot(self):
         dmd = HankelDMD(tlsq_rank=3)
@@ -264,9 +310,8 @@ class TestHODmd(TestCase):
         assert dmd.operator._sorted_eigs == False
 
     def test_sorted_eigs_param(self):
-        dmd = HankelDMD(sorted_eigs='real')
-        assert dmd.operator._sorted_eigs == 'real'
-
+        dmd = HankelDMD(sorted_eigs="real")
+        assert dmd.operator._sorted_eigs == "real"
 
     def test_reconstruction_method_constructor_error(self):
         with self.assertRaises(ValueError):
@@ -276,16 +321,27 @@ class TestHODmd(TestCase):
             HankelDMD(reconstruction_method=np.array([1, 2, 3]), d=4)
 
         with self.assertRaises(ValueError):
-            HankelDMD(reconstruction_method=np.array([[1, 2, 3], [3, 4, 5]]), d=3)
-
+            HankelDMD(
+                reconstruction_method=np.array([[1, 2, 3], [3, 4, 5]]), d=3
+            )
 
     def test_reconstruction_method_default_constructor(self):
-        assert HankelDMD()._reconstruction_method == 'first'
+        assert HankelDMD()._reconstruction_method == "first"
 
     def test_reconstruction_method_constructor(self):
-        assert HankelDMD(reconstruction_method='mean')._reconstruction_method == 'mean'
-        assert HankelDMD(reconstruction_method=[3])._reconstruction_method == [3]
-        assert all(HankelDMD(reconstruction_method=np.array([1, 2]), d=2)._reconstruction_method == np.array([1, 2]))
+        assert (
+            HankelDMD(reconstruction_method="mean")._reconstruction_method
+            == "mean"
+        )
+        assert HankelDMD(reconstruction_method=[3])._reconstruction_method == [
+            3
+        ]
+        assert all(
+            HankelDMD(
+                reconstruction_method=np.array([1, 2]), d=2
+            )._reconstruction_method
+            == np.array([1, 2])
+        )
 
     def test_nonan_nomask(self):
         dmd = HankelDMD(d=3)
@@ -302,16 +358,77 @@ class TestHODmd(TestCase):
             assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
 
     def test_rec_method_first(self):
-        dmd = HankelDMD(d=3, reconstruction_method='first')
+        dmd = HankelDMD(d=3, reconstruction_method="first")
         dmd.fit(X=sample_data)
-        assert (dmd.reconstructed_data == dmd.reconstructions_of_timeindex()[:,0].T).all()
+        assert (
+            dmd.reconstructed_data
+            == dmd.reconstructions_of_timeindex()[:, 0].T
+        ).all()
 
     def test_rec_method_mean(self):
-        dmd = HankelDMD(d=3, reconstruction_method='mean')
+        dmd = HankelDMD(d=3, reconstruction_method="mean")
         dmd.fit(X=sample_data)
-        assert (dmd.reconstructed_data.T[2] == np.mean(dmd.reconstructions_of_timeindex(2), axis=0).T).all()
+        assert (
+            dmd.reconstructed_data.T[2]
+            == np.mean(dmd.reconstructions_of_timeindex(2), axis=0).T
+        ).all()
 
     def test_rec_method_weighted(self):
-        dmd = HankelDMD(d=2, reconstruction_method=[10,20])
+        dmd = HankelDMD(d=2, reconstruction_method=[10, 20])
         dmd.fit(X=sample_data)
-        assert (dmd.reconstructed_data.T[4] == np.average(dmd.reconstructions_of_timeindex(4), axis=0, weights=[10,20]).T).all()
+        assert (
+            dmd.reconstructed_data.T[4]
+            == np.average(
+                dmd.reconstructions_of_timeindex(4), axis=0, weights=[10, 20]
+            ).T
+        ).all()
+
+    def test_hankeldmd_timesteps(self):
+        x = np.linspace(0, 10, 64)
+        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+        dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=30).fit(arr)
+        assert len(dmd.dmd_timesteps) == 64
+
+    def test_first_occurences(self):
+        dmd = HankelDMD()
+        x = np.linspace(0, 10, 64)
+        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+        dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
+        assert dmd._hankel_first_occurrence(0) == 0
+        assert dmd._hankel_first_occurrence(1) == 0
+        assert dmd._hankel_first_occurrence(2) == 0
+        assert dmd._hankel_first_occurrence(3) == 1
+        assert dmd._hankel_first_occurrence(4) == 2
+        assert dmd._hankel_first_occurrence(5) == 3
+
+        dmd.dmd_time["tend"] = 100
+        assert dmd._hankel_first_occurrence(100) == 98
+
+        # change scale
+        dmd.dmd_time["t0"] = dmd.original_time["t0"] = x[0]
+        dmd.dmd_time["tend"] = dmd.original_time["tend"] = x[-1]
+        dmd.dmd_time["dt"] = dmd.original_time["dt"] = x[1] - x[0]
+
+        assert dmd._hankel_first_occurrence(x[0]) == 0
+        assert dmd._hankel_first_occurrence(x[1]) == 0
+        assert dmd._hankel_first_occurrence(x[2]) == 0
+        assert dmd._hankel_first_occurrence(x[3]) == 1
+        assert dmd._hankel_first_occurrence(x[-1] + dmd.dmd_time["dt"]) == 62
+
+    def test_update_sub_dmd_time(self):
+        dmd = HankelDMD()
+        x = np.linspace(0, 10, 64)
+        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+        dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
+
+        dmd.dmd_time["tend"] += dmd.dmd_time["dt"] * 20
+        dmd._update_sub_dmd_time()
+
+        # assert that the dt for the sub_dmd is always 1
+        assert dmd._sub_dmd.dmd_time["dt"] == 1
+        assert dmd._sub_dmd.original_time["dt"] == 1
+
+        assert (
+            dmd._sub_dmd.dmd_time["tend"]
+            == dmd._sub_dmd.original_time["tend"] + 20
+        )

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -4,6 +4,7 @@ from pydmd.hodmd import HODMD
 import matplotlib.pyplot as plt
 import numpy as np
 import os
+import pytest
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -150,6 +151,20 @@ class TestHODmd(TestCase):
                                   [5.69109796e+00 + 2.74068833e+00j],
                                   [           0.0 + 0.0j]])
         np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
+
+    def test_dmd_time_5(self):
+        x = np.linspace(0, 10, 64)
+        y = np.cos(x)*np.sin(np.cos(x)) + np.cos(x*.2)
+
+        dmd = HODMD(svd_rank=-1, exact=True, opt=True, d=30, svd_rank_extra=-1)
+        dmd.fit(y)
+
+        dmd.original_time['dt'] = dmd.dmd_time['dt'] = x[1] - x[0]
+        dmd.original_time['t0'] = dmd.dmd_time['t0'] = x[0]
+        dmd.original_time['tend'] = dmd.dmd_time['tend'] = x[-1]
+
+        # assert that the shape of the output is correct
+        assert dmd.reconstructed_data.shape == (1,64)
 
     def test_plot_eigs_1(self):
         dmd = HODMD()
@@ -309,3 +324,9 @@ class TestHODmd(TestCase):
         ]])
         np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
     """
+
+    def test_scalar_func_warning(self):
+        x = np.linspace(0, 10, 64)
+        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+        # we check that this does not fail
+        dmd = HODMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)


### PR DESCRIPTION
In this PR I implemented the following features/fixes in the classes `HODMD, HankelDMD`:
- show warning and use `svd_rank_extra=-1` when `svd_rank_extra=0` and the system is scalar function (one row);
- return `self` in `HODMD.fit` (as we do in all the other implementations);
- replace `np.outer` to repeat the eigenvalues `n` times with the NumPy method `np.repeat` (which is clearer in my opinion);
- `HankelDMD` now contains an auxiliary instance of `DMD` which operates on Hankel pseudo-matrix:
    + This kind of approach is preferable in order to allow `dmd_timesteps` to work as intended, for instance it fixes the error at https://github.com/mathLab/PyDMD/blob/6de9464311a5fde4843f6fa55b6b324eead57a2c/tutorials/tutorial-6-hodmd.py#L22-L30
    + Some work to update the values in `HankelDMD._sub_dmd.dmd_time` after a change to `HankelDMD.dmd_time`was needed (check `HankelDMD. _update_sub_dmd_time` and `HankelDMD._hankel_first_occurrence`);
    + The properties `modes`, `amplitudes`, `operator` and `svd_rank` of `HankelDMD` return the corresponding values of `HankelDMD._sub_dmd`;
- I implemented new tests to verify that the changes integrated in this PR behave as expected.
- I ran the formatter on the files which I worked on in this PR.