### PR TITLE
Fix e-mail issue

### DIFF
--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -291,9 +291,9 @@ class MrDMD(DMDBase):
         dynamics = []
         for i, leaf in enumerate(leaves):
             d = self.dmd_tree[level, leaf].dynamics
-            base = np.zeros(shape=(d.shape[0], 1600), dtype=d.dtype) #TODO
+            base = np.zeros(shape=(d.shape[0], self._snapshots.shape[1]), dtype=d.dtype)
             time_interval = self.partial_time_interval(level, leaf)
-            base[:, int(time_interval['t0']):int(time_interval['tend'])] = d
+            base[:, int(time_interval['t0']):int(time_interval['t0'])+d.shape[1]] = d
             dynamics.append(base)
 
         dynamics = np.vstack(dynamics)

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -12,6 +12,7 @@ import numpy as np
 import scipy.linalg
 import matplotlib.pyplot as plt
 from copy import deepcopy
+from scipy.linalg import block_diag
 
 from .dmdbase import DMDBase, DMDTimeDict
 
@@ -114,8 +115,7 @@ class MrDMD(DMDBase):
         :return: the matrix containing the DMD modes.
         :rtype: numpy.ndarray
         """
-        return np.hstack(
-            tuple([self.partial_modes(i) for i in range(self.max_level + 1)]))
+        return np.hstack([self.partial_modes(i) for i in range(self.max_level + 1)])
 
     @property
     def dynamics(self):
@@ -126,8 +126,7 @@ class MrDMD(DMDBase):
                 row.
         :rtype: numpy.ndarray
         """
-        return np.vstack(
-            tuple([self.partial_dynamics(i) for i in range(self.max_level + 1)]))
+        return np.vstack([self.partial_dynamics(i) for i in range(self.max_level + 1)])
 
     @property
     def eigs(self):
@@ -287,16 +286,9 @@ class MrDMD(DMDBase):
         :rtype: numpy.ndarray
         """
         leaves = self.dmd_tree.index_leaves(level) if node is None else [node]
-
-        dynamics = []
-        for i, leaf in enumerate(leaves):
-            d = self.dmd_tree[level, leaf].dynamics
-            base = np.zeros(shape=(d.shape[0], self._snapshots.shape[1]), dtype=d.dtype)
-            time_interval = self.partial_time_interval(level, leaf)
-            base[:, int(time_interval['t0']):int(time_interval['t0'])+d.shape[1]] = d
-            dynamics.append(base)
-
-        dynamics = np.vstack(dynamics)
+        print(leaves)
+        dynamics = block_diag(*tuple(dmd.dynamics
+            for dmd in map(lambda leaf: self.dmd_tree[level, leaf], leaves)))
         return dynamics
 
     def partial_eigs(self, level, node=None):

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -286,7 +286,6 @@ class MrDMD(DMDBase):
         :rtype: numpy.ndarray
         """
         leaves = self.dmd_tree.index_leaves(level) if node is None else [node]
-        print(leaves)
         dynamics = block_diag(*tuple(dmd.dynamics
             for dmd in map(lambda leaf: self.dmd_tree[level, leaf], leaves)))
         return dynamics

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -6,9 +6,9 @@ from pydmd import DMD
 import matplotlib.pyplot as plt
 import numpy as np
 
-def create_data():
+def create_data(t_size=1600):
     x = np.linspace(-10, 10, 80)
-    t = np.linspace(0, 20, 1600)
+    t = np.linspace(0, 20, t_size)
     Xm, Tm = np.meshgrid(x, t)
 
     D = np.exp(-np.power(old_div(Xm, 2), 2)) * np.exp(0.8j * Tm)
@@ -75,7 +75,7 @@ class TestMrDmd(TestCase):
         dmd = DMD()
         mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
         mrdmd.fit(X=sample_data)
-        assert len(mrdmd.time_window_bins(0, 1600)) == 2**5-1 
+        assert len(mrdmd.time_window_bins(0, 1600)) == 2**5-1
 
     def test_time_window_bins2(self):
         level = 3
@@ -300,4 +300,14 @@ class TestMrDmd(TestCase):
         dmd = DMD()
         mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
         mrdmd.fit(X=sample_data)
+        np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)
+
+    def test_consistency2(self):
+        import sys
+        import numpy
+        numpy.set_printoptions(threshold=sys.maxsize)
+
+        mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
+        mrdmd.fit(X=create_data(t_size=1400))
+
         np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -186,7 +186,7 @@ class TestMrDmd(TestCase):
         mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
         mrdmd.fit(X=sample_data)
         pdynamics = mrdmd.partial_dynamics(level, 3)
-        assert pdynamics.shape == (rank, sample_data.shape[1])
+        assert pdynamics.shape == (rank, sample_data.shape[1] // 2**level)
 
     def test_eigs2(self):
         max_level = 5
@@ -235,7 +235,7 @@ class TestMrDmd(TestCase):
         mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
         mrdmd.fit(X=sample_data)
         pdata = mrdmd.partial_reconstructed_data(level, 3)
-        assert pdata.shape == sample_data.shape
+        assert pdata.shape == (sample_data.shape[0], sample_data.shape[1] // 2**level)
 
     def test_wrong_partial_reconstructed(self):
         max_level = 5


### PR DESCRIPTION
In this commit I tried to fix the bug notified by a user via e-mail.

> I noted that in partial dynamics code (within mrdmd module has timestep (1600) is probably hardcoded. Possibly, the value 1600 comes from the tutorial 3 (MrDMD) time steps. This results in error while working on other possible time steps.

Even though the problem looks fixed and the script runs without errors I notified some problems while running the new test which I introuced in `test_mrdmd.py`:

```python
    def test_consistency2(self):
        import sys
        import numpy
        numpy.set_printoptions(threshold=sys.maxsize)


        mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
        mrdmd.fit(X=create_data(t_size=1400))


        np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)
```

This is the same kind of test of `test_consistency`, but uses a different number of time instants than 1600. When running the test, I get the error:

```
 AssertionError: 
       Arrays are not almost equal to 6 decimals
```

Since I do not know if my change breaks something in mrDMD I'm marking this PR as a draft to be reviewed.

PS: I could not reproduce the error reported by the same user with `plot_eigs`