### PR TITLE
[HankelDMD] Use NumPy instead of loops to collect snapshots

### DIFF
--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -183,6 +183,17 @@ class HankelDMD(DMDBase):
             return reconstructed_snapshots[timeindex]
 
     def _first_reconstructions(self, reconstructions):
+        """Return the first occurrence of each snapshot available in the given
+        matrix (which must be the result of `self._sub_dmd.reconstructed_data`,
+        or have the same shape).
+
+        :param reconstructions: A matrix of (higher-order) snapshots having
+            shape `(space*self.d, time_instants)`
+        :type reconstructions: np.ndarray
+        :return: The first snapshot that occurs in `reconstructions` for each
+            available time instant.
+        :rtype: np.ndarray
+        """
         first_nonmasked_idx = np.repeat(
             np.array(range(reconstructions.shape[0]))[:, None], 2, axis=1
         )

--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -159,28 +159,38 @@ class HankelDMD(DMDBase):
         space_dim = rec.shape[0] // self.d
         time_instants = rec.shape[1] + self.d - 1
 
-        # for each time instance, we take the mean of all its appearences.
-        # each snapshot appears at most d times (for instance, the first and
-        # the last appear only once).
+        # for each time instance, we collect all its appearences.
+        # each snapshot appears at most d times (for instance, the first appears
+        # only once).
         reconstructed_snapshots = np.full(
-            (time_instants, self.d, space_dim), np.nan, dtype=np.complex128
+            (time_instants, self.d, space_dim), np.nan, dtype=rec.dtype
         )
 
-        first_empty = np.zeros((time_instants,), dtype=np.int8)
+        c_idxes = (
+            np.array(range(self.d))[:, None]
+            .repeat(2, axis=1)[None, :]
+            .repeat(rec.shape[1], axis=0)
+        )
+        c_idxes[:,:,0] += np.array(range(rec.shape[1]))[:, None]
 
-        for time_slice_idx in range(rec.shape[1]):
-            time_slice = rec[:, time_slice_idx]
-
-            for i in range(self.d):
-                time_idx = time_slice_idx + i
-                mx = time_slice[space_dim * i : space_dim * (i + 1)]
-                reconstructed_snapshots[time_idx, first_empty[time_idx]] = mx
-                first_empty[time_idx] += 1
+        reconstructed_snapshots[c_idxes[:, :, 0], c_idxes[:, :, 1]] = np.array(
+            np.swapaxes(np.split(rec.T, self.d, axis=1), 0,1)
+        )
 
         if timeindex is None:
             return reconstructed_snapshots
         else:
-            return reconstructed_snapshots[timeindex][: first_empty[timeindex]]
+            return reconstructed_snapshots[timeindex]
+
+    def _first_reconstructions(self, reconstructions):
+        first_nonmasked_idx = np.repeat(
+            np.array(range(reconstructions.shape[0]))[:, None], 2, axis=1
+        )
+        first_nonmasked_idx[self.d - 1 :, 1] = self.d - 1
+
+        return reconstructions[
+            first_nonmasked_idx[:, 0], first_nonmasked_idx[:, 1]
+        ].T
 
     @property
     def reconstructed_data(self):
@@ -190,7 +200,7 @@ class HankelDMD(DMDBase):
         rec = np.ma.array(rec, mask=np.isnan(rec))
 
         if self._reconstruction_method == "first":
-            result = rec[:, 0].T
+            result = self._first_reconstructions(rec)
         elif self._reconstruction_method == "mean":
             result = np.mean(rec, axis=1).T
         elif isinstance(self._reconstruction_method, list) or isinstance(

--- a/tests/test_hankeldmd.py
+++ b/tests/test_hankeldmd.py
@@ -360,10 +360,11 @@ class TestHankelDmd(TestCase):
     def test_rec_method_first(self):
         dmd = HankelDMD(d=3, reconstruction_method="first")
         dmd.fit(X=sample_data)
-        assert (
-            dmd.reconstructed_data
-            == dmd.reconstructions_of_timeindex()[:, 0].T
-        ).all()
+
+        rec = dmd.reconstructed_data
+        allrec = dmd.reconstructions_of_timeindex()
+        for i in range(rec.shape[1]):
+            assert (rec[:,i] == allrec[i, min(i,dmd.d-1)]).all()
 
     def test_rec_method_mean(self):
         dmd = HankelDMD(d=3, reconstruction_method="mean")

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -295,9 +295,13 @@ class TestHODmd(TestCase):
             assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
 
     def test_rec_method_first(self):
-        dmd = HODMD(d=3, reconstruction_method='first')
+        dmd = HODMD(d=3, reconstruction_method="first")
         dmd.fit(X=sample_data)
-        assert (dmd.reconstructed_data == dmd.reconstructions_of_timeindex()[:,0].T).all()
+
+        rec = dmd.reconstructed_data
+        allrec = dmd.reconstructions_of_timeindex()
+        for i in range(rec.shape[1]):
+            assert (rec[:,i] == allrec[i, min(i,dmd.d-1)]).all()
 
     def test_rec_method_mean(self):
         dmd = HODMD(d=3, reconstruction_method='mean')


### PR DESCRIPTION
In this commit I changed the approach used to collect snapshots from the reconstruction provided by the "higher order" DMD instance, and place them into an appropriate matrix according to their position. 

The former approach used several loops to reach the goal; however the NumPy-approach is quite faster as you can see in the following image (https://github.com/nschloe/perfplot):

![perf](https://user-images.githubusercontent.com/8464342/134769756-25d7a9d1-c823-4d09-864e-d21d9e636688.png)
