### PR TITLE
[HODMD/HankelDMD] Improve explanation of the parameter reconstruction_method 

### DIFF
--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -44,13 +44,14 @@ class HankelDMD(DMDBase):
         magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
         part to break ties) if `sorted_eigs='real'`. Default: False.
     :type sorted_eigs: {'real', 'abs'} or False
-    :param reconstruction_method: Due to how HODMD is defined, we have several
-        versions of the same snapshot. The parameter `reconstruction_method`
-        allows changing how these versions are combined in
-        `reconstructed_data`.  If `'first'`, only the first version is selected
-        (default behavior); if `'mean'` we take the mean of all the versions;
-        if the parameter is an array of floats of size `d`, the return value is
-        the weighted average of the versions.
+    :param reconstruction_method: Method used to reconstruct the snapshots of
+        the dynamical system from the multiple versions available due to how
+        HankelDMD is conceived. If `'first'` (default) the first version
+        available is selected (i.e. the nearest to the 0-th row in the
+        augmented matrix). If `'mean'` we compute the element-wise mean. If
+        `reconstruction_method` is an array of float values we compute the
+        weighted average (for each snapshots) using the given values as weights
+        (the number of weights must be equal to `d`).
     :type reconstruction_method: {'first', 'mean'} or array-like
     """
 

--- a/pydmd/hodmd.py
+++ b/pydmd/hodmd.py
@@ -44,14 +44,14 @@ class HODMD(HankelDMD):
         magnitude if `sorted_eigs='abs'`, by real part (and then by imaginary
         part to break ties) if `sorted_eigs='real'`. Default: False.
     :type sorted_eigs: {'real', 'abs'} or False
-    :param reconstruction_method: Due to how HODMD is defined, we have several
-        versions of the same snapshot. The parameter `reconstruction_method`
-        allows changing how these versions are combined in
-        `reconstructed_data`.  If `'first'`, only the first version is selected
-        (default behavior); if `'mean'` we take the mean of all the versions;
-        if the parameter is an array of floats of size `d`, the return value is
-        the weighted average of the versions.
-    :type reconstruction_method: {'first', 'mean'} or array-like
+    :param reconstruction_method: Method used to reconstruct the snapshots of
+        the dynamical system from the multiple versions available due to how
+        HODMD is conceived. If `'first'` (default) the first version
+        available is selected (i.e. the nearest to the 0-th row in the
+        augmented matrix). If `'mean'` we compute the element-wise mean. If
+        `reconstruction_method` is an array of float values we compute the
+        weighted average (for each snapshots) using the given values as weights
+        (the number of weights must be equal to `d`).
     :param svd_rank_extra: the rank for the initial reduction of the input
         data, performed before the rearrangement of the input data to the
         (pseudo) Hankel matrix format; If 0, the method computes the optimal


### PR DESCRIPTION
Following an e-mail we received today I decided to improve the explanation I wrote several months ago regarding the parameter `reconstruction_method` which controls how the snapshots are extracted from the set of "artificial snapshots" which are made available by the way in which HankelDMD is conceived.