### PR TITLE
Ignore jupyter notebooks in languages percentage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tutorials/* linguist-vendored=true
+tutorials/** linguist-vendored=true


### PR DESCRIPTION
Since the structure of the folder `tutorials` changed several commits ago the language counter is considering Jupyter Notebooks again. This commit should fix the issue.