### PR TITLE
[BUG] Fix `threshold` selection method 

### DIFF
--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -512,15 +512,18 @@ matrix, or regularization methods.""".format(
             :return np.ndarray: An array of bool, where each "True" index means
                 that the corresponding DMD mode is selected.
             """
+            eigs_module = np.abs(dmd.eigs)
+
             return np.logical_and(
-                dmd.eigs < up_threshold,
-                dmd.eigs > low_threshold,
+                eigs_module < up_threshold,
+                eigs_module > low_threshold,
             )
 
         @staticmethod
         def threshold(low_threshold, up_threshold):
             """
-            Complete function of the modes selector `threshold`.
+            Retain only DMD modes associated with an eigenvalue whose module is
+            between `low_threshold` and `up_threshold`.
 
             :param float low_threshold: The minimum accepted module of an
                 eigenvalue.

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -164,7 +164,7 @@ class TestDmdBase(TestCase):
             pass
 
         fake_dmd = FakeDMD()
-        setattr(fake_dmd, 'eigs', np.array([1 + 1e-4, 2, 1 - 1e-2, 5, 1, 1 + 2*1e-3]))
+        setattr(fake_dmd, 'eigs', np.array([complex(1, 1e-4), 2, complex(1, 1e-2), 5, 1, complex(1, 5*1e-2)]))
 
         expected_result = np.array([False for _ in range(6)])
         expected_result[[1, 5]] = True


### PR DESCRIPTION
In this PR I fixed the `threshold` selection method which used to fail since the comparison with `low_threshold` and `up_threshold` was made against actual DMD eigenvalues instead of their module. The test case did not detect this behavior since the eigenvalues used in its code were real numbers.