### PR TITLE
`ModesTuner` now accepts lists of DMDs to allow simultaneous tuning

### DIFF
--- a/pydmd/dmd_modes_tuner.py
+++ b/pydmd/dmd_modes_tuner.py
@@ -396,10 +396,12 @@ class ModesTuner:
     :param dmd: An instance of DMD (will be copied via `deepcopy`,
         therefore the given reference won't be modified afterwards).
     :type dmd: pydmd.DMDBase
+    :param bool in_place: If `True`, this tuner works directly on the given
+        DMD instance.
     """
 
-    def __init__(self, dmd):
-        self._dmd = deepcopy(dmd)
+    def __init__(self, dmd, in_place=False):
+        self._dmd = dmd if in_place else deepcopy(dmd)
 
     @property
     def dmd(self):
@@ -417,7 +419,7 @@ class ModesTuner:
     def secure_copy(self):
         """Returns a deep copy of the private DMD instance that `ModesTuner` is
         working on. This is not going to be modified by calls to tuning
-        methods.
+        methods, and therefore provides a secure "snapshot" of the DMD.
 
         :return: A copy of the private DMD instance owned by `ModesTuner`.
         :rtype: pydmd.DMDBase
@@ -465,8 +467,10 @@ class ModesTuner:
                 raise ValueError("Could't find the specified criteria")
             criteria = selectors[criteria](**kwargs)
         if not callable(criteria):
-            raise ValueError("""You should provide a criteria to select DMD
-modes (either a string or a function)""")
+            raise ValueError(
+                """You should provide a criteria to select DMD
+modes (either a string or a function)"""
+            )
 
         select_modes(self.dmd, criteria)
 

--- a/pydmd/dmd_modes_tuner.py
+++ b/pydmd/dmd_modes_tuner.py
@@ -393,38 +393,49 @@ class ModesTuner:
     tuning, or to check which modes have been changed) you may prefer to
     use them instead.
 
-    :param dmd: An instance of DMD (will be copied via `deepcopy`,
-        therefore the given reference won't be modified afterwards).
-    :type dmd: pydmd.DMDBase
+    :param dmds: One or more instances of DMD.
+    :type dmd: list or pydmd.DMDBase
     :param bool in_place: If `True`, this tuner works directly on the given
         DMD instance.
     """
 
-    def __init__(self, dmd, in_place=False):
-        self._dmd = dmd if in_place else deepcopy(dmd)
+    def __init__(self, dmds, in_place=False):
+        # if True, we return a list since we received a list in the constructor
+        self._init_received_list = isinstance(dmds, list)
 
-    @property
-    def dmd(self):
-        """Returns the private DMD instance that `ModesTuner` is working on.
-        Be aware that this instance is the internal instance owned by
-        `ModesTuner`, therefore it is going to be modified by calls to tuning
-        methods.
+        dmds = dmds if self._init_received_list else [dmds]
+        self._dmds = dmds if in_place else list(map(deepcopy, dmds))
 
-        :return: The private DMD instance owned by `ModesTuner`.
-        :rtype: pydmd.DMDBase
+    def get(self):
+        """Returns the private DMD instance(s) that `ModesTuner` is working on.
+        Be aware that those instances are the internal instances owned by
+        `ModesTuner`, therefore they are going going to be modified by
+        subsequent calls to tuning methods.
+
+        :return: The private DMD instance owned by `ModesTuner`, or a list of
+            DMD instances depending on the parameter received by the
+            constructor of this instance.
+        :rtype: list or pydmd.DMDBase
         """
-        return self._dmd
 
-    @property
-    def secure_copy(self):
-        """Returns a deep copy of the private DMD instance that `ModesTuner` is
-        working on. This is not going to be modified by calls to tuning
-        methods, and therefore provides a secure "snapshot" of the DMD.
+        if self._init_received_list:
+            return self._dmds
+        return self._dmds[0]
 
-        :return: A copy of the private DMD instance owned by `ModesTuner`.
-        :rtype: pydmd.DMDBase
+    def copy(self):
+        """Returns a deep copy of the private DMD instance(s) that `ModesTuner`
+        is working on. They are not going to be modified by subsequent calls to
+        tuning methods, and therefore provide a secure "snapshot" to the DMD(s).
+
+        :return: A copy of the private DMD instance owned by `ModesTuner`, or a
+            list of copies depending on the parameter received by the
+            constructor of this instance.
+        :rtype: list or pydmd.DMDBase
         """
-        return deepcopy(self.dmd)
+
+        if self._init_received_list:
+            return list(map(deepcopy, self._dmds))
+        return deepcopy(self._dmds[0])
 
     def select(self, criteria, **kwargs):
         r"""
@@ -472,7 +483,8 @@ class ModesTuner:
 modes (either a string or a function)"""
             )
 
-        select_modes(self.dmd, criteria)
+        for dmd in self._dmds:
+            select_modes(dmd, criteria)
 
     def stabilize(self, inner_radius, outer_radius=np.inf):
         """
@@ -500,4 +512,5 @@ modes (either a string or a function)"""
             be stabilized.
         """
 
-        stabilize_modes(self.dmd, inner_radius, outer_radius)
+        for dmd in self._dmds:
+            stabilize_modes(dmd, inner_radius, outer_radius)

--- a/pydmd/dmd_modes_tuner.py
+++ b/pydmd/dmd_modes_tuner.py
@@ -406,6 +406,21 @@ class ModesTuner:
         dmds = dmds if self._init_received_list else [dmds]
         self._dmds = dmds if in_place else list(map(deepcopy, dmds))
 
+    def subset(self, indexes):
+        """
+        Generate a temporary instance of `ModesTuner` which operates on a
+        subset of the DMD instances held by this `ModesTuner`.
+
+        :param list indexes: List of indexes of the DMD instances to be put
+            into the subset.
+        :return ModesTuner: A `ModesTuner` which operates "in place" on the
+            DMD instances held by the caller `ModesTuner`.
+        """
+        if not self._init_received_list:
+            raise ValueError("Cannot index a single DMD instance.")
+
+        return ModesTuner([self._dmds[i] for i in indexes], in_place=True)
+
     def get(self):
         """Returns the private DMD instance(s) that `ModesTuner` is working on.
         Be aware that those instances are the internal instances owned by

--- a/tests/test_dmd_modes_tuner.py
+++ b/tests/test_dmd_modes_tuner.py
@@ -270,10 +270,43 @@ def test_modes_tuner_copy():
     fake_dmd = FakeDMD()
     setattr(fake_dmd, 'eigs', np.array([complex(1, 1e-4), 2, complex(1, 1e-2), 5, 1, complex(1, 5*1e-2)]))
 
-    ModesTuner(fake_dmd)._dmd.eigs[1] = 0
+    ModesTuner(fake_dmd)._dmds[0].eigs[1] = 0
     assert fake_dmd.eigs[1] == 2
 
-def test_modes_tuner_dmd():
+# assert that passing a scalar DMD (i.e. no list) causes ModesTuner to return
+# only scalar DMD instances
+def test_modes_tuner_scalar_input():
+    class FakeDMD:
+        pass
+
+    fake_dmd = FakeDMD()
+    setattr(fake_dmd, 'eigs', np.array([complex(1, 1e-4), 2, complex(1, 1e-2), 5, 1, complex(1, 5*1e-2)]))
+
+    mt = ModesTuner(fake_dmd, in_place=True)
+    assert mt.get() == fake_dmd
+    assert isinstance(mt.copy(), FakeDMD)
+
+def test_modes_tuner_list_input():
+    class FakeDMD:
+        pass
+
+    def cook_fake_dmd():
+        fake_dmd = FakeDMD()
+        setattr(fake_dmd, 'eigs', np.array([complex(1, 1e-4), 2, complex(1, 1e-2), 5, 1, complex(1, 5*1e-2)]))
+        return fake_dmd
+
+    dmd1 = cook_fake_dmd()
+    dmd2 = cook_fake_dmd()
+
+    mt = ModesTuner([dmd1, dmd2], in_place=True)
+    assert isinstance(mt.get(), list)
+    assert mt.get()[0] == dmd1
+    assert mt.get()[1] == dmd2
+
+    assert isinstance(mt.copy(), list)
+    assert len(mt.copy()) == 2
+
+def test_modes_tuner_get():
     class FakeDMD:
         pass
 
@@ -282,8 +315,8 @@ def test_modes_tuner_dmd():
 
     mtuner = ModesTuner(fake_dmd)
 
-    eigs = mtuner.dmd.eigs
-    mtuner._dmd.eigs[1] = 0
+    eigs = mtuner.get().eigs
+    mtuner._dmds[0].eigs[1] = 0
     assert eigs[1] == 0
 
 def test_modes_tuner_secure_copy():
@@ -295,8 +328,8 @@ def test_modes_tuner_secure_copy():
 
     mtuner = ModesTuner(fake_dmd)
 
-    eigs = mtuner.secure_copy.eigs
-    mtuner._dmd.eigs[1] = 0
+    eigs = mtuner.copy().eigs
+    mtuner._dmds[0].eigs[1] = 0
     assert eigs[1] == 2
 
 def test_modes_tuner_inplace():
@@ -308,7 +341,7 @@ def test_modes_tuner_inplace():
 
     mtuner = ModesTuner(fake_dmd, in_place=True)
 
-    mtuner._dmd.eigs[1] = 0
+    mtuner._dmds[0].eigs[1] = 0
     assert fake_dmd.eigs[1] == 0
 
 def test_modes_tuner_select_raises():
@@ -347,7 +380,7 @@ def test_modes_tuner_select():
 
     mtuner = ModesTuner(fake_dmd)
     mtuner.select('stable_modes', max_distance_from_unity=1e-3)
-    dmd = mtuner.dmd
+    dmd = mtuner.get()
 
     assert len(dmd.operator._eigenvalues) == 3
     assert len(dmd.operator._Lambda) == 3
@@ -372,7 +405,7 @@ def test_modes_tuner_stabilize():
 
     mtuner = ModesTuner(dmd)
     mtuner.stabilize(inner_radius=0.8, outer_radius=1.2)
-    dmd = mtuner.dmd
+    dmd = mtuner.get()
 
     np.testing.assert_array_almost_equal(
         dmd.operator._eigenvalues,
@@ -382,6 +415,45 @@ def test_modes_tuner_stabilize():
     np.testing.assert_array_almost_equal(
         dmd._b,
         np.array([1, 2*abs(complex(0.8,0.5)), 3, 4*abs(complex(1,1.e-2)), 5, 6]))
+
+def test_modes_tuner_stabilize_multiple():
+    class FakeDMDOperator:
+        pass
+
+    def cook_fake_dmd():
+        dmd = DMD()
+        fake_dmd_operator = FakeDMDOperator()
+
+        eigs = np.array([complex(0.3, 0.2), complex(0.8,0.5), 1, complex(1,1.e-2), 2, complex(2,1.e-2)])
+        amplitudes = np.array([1,2,3,4,5,6], dtype=complex)
+
+        setattr(fake_dmd_operator, '_eigenvalues', eigs)
+        setattr(fake_dmd_operator, 'eigenvalues', eigs)
+        setattr(dmd, '_Atilde', fake_dmd_operator)
+
+        setattr(dmd, '_b', amplitudes)
+
+        return dmd
+
+    dmd1 = cook_fake_dmd()
+    dmd2 = cook_fake_dmd()
+    dmd3 = cook_fake_dmd()
+
+    mtuner = ModesTuner([dmd1, dmd2, dmd3])
+    mtuner.stabilize(inner_radius=0.8, outer_radius=1.2)
+    dmds = mtuner.get()
+
+    assert isinstance(dmds, list)
+
+    for dmd in dmds:
+        np.testing.assert_array_almost_equal(
+            dmd.operator._eigenvalues,
+            np.array([complex(0.3, 0.2), complex(0.8,0.5) / abs(complex(0.8,0.5)),
+                1, complex(1,1.e-2) / abs(complex(1,1.e-2)), 2, complex(2,1.e-2)]))
+
+        np.testing.assert_array_almost_equal(
+            dmd._b,
+            np.array([1, 2*abs(complex(0.8,0.5)), 3, 4*abs(complex(1,1.e-2)), 5, 6]))
 
 def test_modes_tuner_selectors():
     assert selectors['module_threshold'] == ModesSelectors.threshold

--- a/tests/test_dmd_modes_tuner.py
+++ b/tests/test_dmd_modes_tuner.py
@@ -299,6 +299,18 @@ def test_modes_tuner_secure_copy():
     mtuner._dmd.eigs[1] = 0
     assert eigs[1] == 2
 
+def test_modes_tuner_inplace():
+    class FakeDMD:
+        pass
+
+    fake_dmd = FakeDMD()
+    setattr(fake_dmd, 'eigs', np.array([complex(1, 1e-4), 2, complex(1, 1e-2), 5, 1, complex(1, 5*1e-2)]))
+
+    mtuner = ModesTuner(fake_dmd, in_place=True)
+
+    mtuner._dmd.eigs[1] = 0
+    assert fake_dmd.eigs[1] == 0
+
 def test_modes_tuner_select_raises():
     class FakeDMD:
         pass


### PR DESCRIPTION
In this PR I improved `ModesTuner` in order to allow passing lists of DMDs in the constructor. This allows simultaneous tuning of multiple DMD instances, i.e. instead of doing this:
```python
dmd1 = ...
dmd2 = ...

tuner1 = ModesTuner(dmd1)
tuner1.stabilize(inner_radius=1-1.e-3, outer_radius=1+1.e-3)
tuner1.select(criteria='integral_contribution', n=4)
dmd1 = tuner1.get()

tuner2 = ModesTuner(dmd2)
tuner2.stabilize(inner_radius=1-1.e-3, outer_radius=1+1.e-3)
tuner2.select(criteria='integral_contribution', n=4)
dmd2 = tuner2.get()
```

we can compress the code and do this (which looks somewhat more Pythonic):
```python
tuner = ModesTuner([dmd1, dmd2])
tuner.stabilize(inner_radius=1-1.e-3, outer_radius=1+1.e-3)
tuner.select(criteria='integral_contribution', n=4)
dmd1, dmd2 = tuner.get()
```

This also allows more seamless integrations, in particular with `ParametricDMD` (more to come). 

I also introduced a new parameter `in_place` (default `False`) to choose whether the given DMD(s) can be modified in-place or not (if not, a`deepcopy` is performed for each DMD).