### PR TITLE
Documentation: Fix broken tutorial links.

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -6,11 +6,11 @@ An additional PDF tutorial ([DSWeb contest winner](https://dsweb.siam.org/The-Ma
 
 | Name  | Description   | PyDMD used classes |
 |-------|---------------|--------------------|
-| Tutorial1&#160;[[.ipynb](tutorial1/tutorial-1-dmd.ipynb),&#160;[.py](tutorial1/tutorial-1-dmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial1ffd.html)]| basic usage of standard DMD | `pydmd.DMD` |
+| Tutorial1&#160;[[.ipynb](tutorial1/tutorial-1-dmd.ipynb),&#160;[.py](tutorial1/tutorial-1-dmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial1dmd.html)]| basic usage of standard DMD | `pydmd.DMD` |
 | Tutorial2&#160;[[.ipynb](tutorial2/tutorial-2-adv-dmd.ipynb),&#160;[.py](tutorial2/tutorial-2-adv-dmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial2advdmd.html)] | advanced features of standard DMD | `pydmd.DMD`  |
 | Tutorial3&#160;[[.ipynb](tutorial3/tutorial-3-mrdmd.ipynb),&#160;[.py](tutorial3/tutorial-3-mrdmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial3mrdmd.html)] | multi-resolution DMD for transient phenomena | `pydmd.MrDMD` |
 | Tutorial4&#160;[[.ipynb](tutorial4/tutorial-4-cdmd.ipynb),&#160;[.py](tutorial4/tutorial-4-cdmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial4cdmd.html)] | compress DMD for computation speedup | `pydmd.CDMD`  |
-| Tutorial5&#160;[[.ipynb](tutorial5/tutorial-5-fbdmd.ipynb),&#160;[.py](tutorial5/tutorial-5-fbdmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial-5-fbdmd.html)] | forward-backward DMD for CFD model analysis | `pydmd.FbDMD`  |
+| Tutorial5&#160;[[.ipynb](tutorial5/tutorial-5-fbdmd.ipynb),&#160;[.py](tutorial5/tutorial-5-fbdmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial5fbdmd.html)] | forward-backward DMD for CFD model analysis | `pydmd.FbDMD`  |
 | Tutorial6&#160;[[.ipynb](tutorial6/tutorial-6-hodmd.ipynb),&#160;[.py](tutorial6/tutorial-6-hodmd.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial6hodmd.html)] | higher-order DMD applied to scalar time-series | `pydmd.HODMD`  |
 | Tutorial7&#160;[[.ipynb](tutorial7/tutorial-7-dmdc.ipynb),&#160;[.py](tutorial7/tutorial-7-dmdc.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial7dmdc.html)] | DMD with control | `pydmd.DMDC`  |
 | Tutorial8&#160;[[.ipynb](tutorial8/tutorial-8-comparisons.ipynb),&#160;[.py](tutorial8/tutorial-8-comparisons.py),&#160;[.html](http://mathlab.github.io/PyDMD/tutorial8comparison.html)] | comparison between DMD and optimal closed-form DMD | `pydmd.OptDMD`  |


### PR DESCRIPTION
The links for the html documentation for tutorials 1 and 5
were broken, which resulted in a 404 error.