### PR TITLE
Cleanup time dict interface (`DMDBase.original_time/dmd_time`)

### DIFF
--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.sparse
 from scipy.linalg import sqrtm
 
-from .dmdbase import DMDBase, DMDTimeDict
+from .dmdbase import DMDBase
 from .dmdoperator import DMDOperator
 
 from .utils import compute_tlsq, compute_svd
@@ -201,9 +201,9 @@ class CDMD(DMDBase):
         self.operator.compute_operator(X, Y, self._snapshots[:, 1:])
 
         # Default timesteps
-        self.original_time = DMDTimeDict(
-            {'t0': 0, 'tend': n_samples - 1, 'dt': 1})
-        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self._set_initial_time_dictionary(
+            {"t0": 0, "tend": n_samples - 1, "dt": 1}
+        )
 
         self._b = self._compute_amplitudes()
 

--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -5,7 +5,7 @@ Derived module from dmdbase.py for classic dmd.
 import numpy as np
 from scipy.linalg import pinv2
 
-from .dmdbase import DMDBase, DMDTimeDict
+from .dmdbase import DMDBase
 from .utils import compute_tlsq
 
 
@@ -63,9 +63,9 @@ class DMD(DMDBase):
         self._svd_modes, _, _ = self.operator.compute_operator(X, Y)
 
         # Default timesteps
-        self.original_time = DMDTimeDict(
-            {'t0': 0, 'tend': n_samples - 1, 'dt': 1})
-        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self._set_initial_time_dictionary(
+            {"t0": 0, "tend": n_samples - 1, "dt": 1}
+        )
 
         self._b = self._compute_amplitudes()
 
@@ -86,4 +86,5 @@ class DMD(DMDBase):
 
         """
         return np.linalg.multi_dot(
-            [self.modes, np.diag(self.eigs), pinv(self.modes), X])
+            [self.modes, np.diag(self.eigs), pinv(self.modes), X]
+        )

--- a/pydmd/dmd_modes_tuner.py
+++ b/pydmd/dmd_modes_tuner.py
@@ -339,13 +339,13 @@ and `max_distance_from_unity_outside` can be not `None`"""
 
         # temporary reset dmd_time to original_time
         temp = dmd.dmd_time
-        dmd.dmd_time = dmd.original_time
+        dmd._dmd_time = dmd.original_time
 
         dynamics = dmd.dynamics
         modes = dmd.modes
 
         # reset dmd_time
-        dmd.dmd_time = temp
+        dmd._dmd_time = temp
 
         n_of_modes = modes.shape[1]
         integral_contributions = [

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -96,8 +96,8 @@ class DMDBase(object):
         )
 
         self._tlsq_rank = tlsq_rank
-        self.original_time = None
-        self.dmd_time = None
+        self._original_time = None
+        self._dmd_time = None
         self._opt = opt
 
         self._b = None  # amplitudes
@@ -303,6 +303,81 @@ class DMDBase(object):
         :rtype: numpy.ndarray
         """
         return self._b
+
+    @property
+    def original_time(self):
+        """
+        A dictionary which contains information about the time window used to
+        fit this DMD instance.
+
+        Inside the dictionary:
+
+        ======  ====================================================================================
+        Key     Value
+        ======  ====================================================================================
+        `t0`    Time of the first input snapshot (0 by default).
+        `tend`  Time of the last input snapshot (usually corresponds to the number of snapshots).
+        `dt`    Timestep between two snapshots (1 by default).
+        ======  ====================================================================================
+
+        :return: A dict which contains info about the input time frame.
+        :rtype: dict
+        """
+        if self._original_time is None:
+            raise RuntimeError(
+                """
+_set_initial_time_dictionary() has not been called, did you call fit()?"""
+            )
+        return self._original_time
+
+    @property
+    def dmd_time(self):
+        """
+        A dictionary which contains information about the time window used to
+        reconstruct/predict using this DMD instance. By default this is equal
+        to :func:`original_time`.
+
+        Inside the dictionary:
+
+        ======  ====================================================================================
+        Key     Value
+        ======  ====================================================================================
+        `t0`    Time of the first output snapshot.
+        `tend`  Time of the last output snapshot.
+        `dt`    Timestep between two snapshots.
+        ======  ====================================================================================
+
+        :return: A dict which contains info about the input time frame.
+        :rtype: dict
+        """
+        if self._dmd_time is None:
+            raise RuntimeError(
+                """
+_set_initial_time_dictionary() has not been called, did you call fit()?"""
+            )
+        return self._dmd_time
+
+    def _set_initial_time_dictionary(self, time_dict):
+        """
+        Set the initial values for the class fields `time_dict` and
+        `original_time`. This is usually called in `fit()` and never again.
+
+        :param time_dict: Initial time dictionary for this DMD instance.
+        :type time_dict: dict
+        """
+        if not (
+            "t0" in time_dict and "tend" in time_dict and "dt" in time_dict
+        ):
+            raise ValueError(
+                'time_dict must contain the keys "t0", "tend" and "dt".'
+            )
+        if len(time_dict) > 3:
+            raise ValueError(
+                'time_dict must contain only the keys "t0", "tend" and "dt".'
+            )
+
+        self._original_time = DMDTimeDict(dict(time_dict))
+        self._dmd_time = DMDTimeDict(dict(time_dict))
 
     def fit(self, X):
         """

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -8,7 +8,7 @@ with control. SIAM Journal on Applied Dynamical Systems, 15(1), pp.142-161.
 from past.utils import old_div
 import numpy as np
 
-from .dmdbase import DMDBase, DMDTimeDict
+from .dmdbase import DMDBase
 from .dmdoperator import DMDOperator
 from .utils import compute_tlsq, compute_svd
 
@@ -281,9 +281,9 @@ class DMDc(DMDBase):
         X = self._snapshots[:, :-1]
         Y = self._snapshots[:, 1:]
 
-        self.original_time = DMDTimeDict(
-            {'t0': 0, 'tend': n_samples - 1, 'dt': 1})
-        self.dmd_time = DMDTimeDict({'t0': 0, 'tend': n_samples - 1, 'dt': 1})
+        self._set_initial_time_dictionary(
+            {"t0": 0, "tend": n_samples - 1, "dt": 1}
+        )
 
         if B is None:
             self._Atilde = DMDBUnknownOperator(**self._dmd_operator_kwargs)

--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -8,7 +8,7 @@ Applied Dynamical Systems, 2017, 16.4: 2096-2126.
 """
 import numpy as np
 
-from .dmdbase import DMDBase, DMDTimeDict
+from .dmdbase import DMDBase
 from .dmd import DMD
 
 
@@ -281,9 +281,8 @@ class HankelDMD(DMDBase):
 
         # Default timesteps
         n_samples = snp.shape[1]
-        self.original_time = DMDTimeDict(
+        self._set_initial_time_dictionary(
             {"t0": 0, "tend": n_samples - 1, "dt": 1}
         )
-        self.dmd_time = DMDTimeDict({"t0": 0, "tend": n_samples - 1, "dt": 1})
 
         return self

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 from copy import deepcopy
 from scipy.linalg import block_diag
 
-from .dmdbase import DMDBase, DMDTimeDict
+from .dmdbase import DMDBase
 from .dmd_modes_tuner import ModesSelectors, select_modes
 
 
@@ -78,36 +78,6 @@ class MrDMD(DMDBase):
 
     def __iter__(self):
         return self.dmd_tree.__iter__()
-
-    @property
-    def original_time(self):
-        """
-        Returns the dictionary that contains information about the
-        time window where the system is sampled:
-
-           - `t0` is the time of the first input snapshot;
-           - `tend` is the time of the last input snapshot;
-           - `dt` is the delta time between the snapshots.
-
-        :return: the original time window information.
-        :rtype: dict
-        """
-        return self._original_time
-
-    @property
-    def dmd_time(self):
-        """
-        Returns the dictionary that contains information about the
-        time window where the system is reconstructed:
-
-           - `t0` is the time of the first input snapshot;
-           - `tend` is the time of the last input snapshot;
-           - `dt` is the delta time between the snapshots.
-
-        :return: the reconstruction time window information.
-        :rtype: dict
-        """
-        return self._dmd_time
 
     @property
     def modes(self):
@@ -437,10 +407,7 @@ class MrDMD(DMDBase):
             ).astype(X.dtype)
             X -= newX
 
-        self._dmd_time = DMDTimeDict(
-            dict(t0=0, tend=self._snapshots.shape[1], dt=1)
-        )
-        self._original_time = DMDTimeDict(
+        self._set_initial_time_dictionary(
             dict(t0=0, tend=self._snapshots.shape[1], dt=1)
         )
 

--- a/pydmd/paramdmd.py
+++ b/pydmd/paramdmd.py
@@ -72,7 +72,7 @@ class ParametricDMD:
         :func:`_reference_dmd`).
 
         :return: The time dictionary used by this instance.
-        :rtype: pydmd.dmdbase.DMDTimeDict
+        :rtype: dict
         """
         return self._reference_dmd.dmd_time
 
@@ -96,7 +96,7 @@ class ParametricDMD:
         (see :func:`_reference_dmd`).
 
         :return: The original time dictionary used by this instance.
-        :rtype: pydmd.dmdbase.DMDTimeDict
+        :rtype: dict
         """
         return self._reference_dmd.original_time
 
@@ -270,13 +270,10 @@ class ParametricDMD:
             # partitioned parametric DMD
             for dmd, data in zip(self._dmd, training_modal_coefficients):
                 dmd.fit(data)
-
-                if self._reference_dmd.dmd_time is None:
-                    raise ValueError(
-                        "For some reason the reference DMD has "
-                        "not been fit before the others."
-                    )
-                dmd.dmd_time = self._reference_dmd.dmd_time
+                # we want to "bound" this DMD objects "dmd_time"
+                # and "original_time" to those of the reference_dmd.
+                dmd._dmd_time = self._reference_dmd.dmd_time
+                dmd._original_time = self._reference_dmd.dmd_time
         else:
             spacemu_time = np.vstack(training_modal_coefficients)
             self._dmd.fit(spacemu_time)


### PR DESCRIPTION
In this PR I changed the interface for time dictionaries exposed by `DMDBase`. 

First of all I introduced the method `DMDBase._set_initial_time_dictionary`, which must be called in the implementations of `DMDBase.fit()` and requires a dictionary. This method performs the usual check on the given dictionary, and then creates two instances of `DMDTimeDict` which are assigned to the (private) fields `_dmd_time` and `_original_time`.

This removes the need to import and use `DMDTimeDict`, and therefore simplifies the code in `fit()`.

I also changed `dmd_time` and `original_time` from fields to properties, therefore we can now document them properly and maybe perform some checks/disable wrongful write accesses.