### PR TITLE
Implement `__getitem__` for `DMDBase` subclasses

### DIFF
--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -115,6 +115,14 @@ class MrDMD(DMDBase):
         return np.concatenate([dmd.eigs for dmd in self])
 
     @property
+    def modes_activation_bitmask(self):
+        raise RuntimeError("This feature has not been implemented yet.")
+
+    @modes_activation_bitmask.setter
+    def modes_activation_bitmask(self, value):
+        raise RuntimeError("This feature has not been implemented yet.")
+
+    @property
     def reconstructed_data(self):
         """
         Get the reconstructed data.

--- a/pydmd/optdmd.py
+++ b/pydmd/optdmd.py
@@ -59,7 +59,7 @@ class DMDOptOperator(DMDOperator):
             forward_backward=False,
             rescale_mode=None,
             sorted_eigs=False,
-            tikhonov_regularization=None
+            tikhonov_regularization=None,
         )
         self._factorization = factorization
 
@@ -261,6 +261,14 @@ class OptDMD(DMDBase):
 
         return Y
 
+    @property
+    def modes_activation_bitmask(self):
+        raise RuntimeError("This feature has not been implemented yet.")
+
+    @modes_activation_bitmask.setter
+    def modes_activation_bitmask(self, value):
+        raise RuntimeError("This feature has not been implemented yet.")
+
     def _compute_amplitudes(self, modes, snapshots, eigs, opt):
         raise NotImplementedError(
             "This function has not been implemented yet."
@@ -285,7 +293,7 @@ class OptDMD(DMDBase):
         )
 
     @modes_activation_bitmask.setter
-    def modes_activation_bitmask(self):
+    def modes_activation_bitmask(self, value):
         raise NotImplementedError(
             "This function has not been implemented yet."
         )

--- a/tests/test_cdmd.py
+++ b/tests/test_cdmd.py
@@ -1,5 +1,6 @@
 from builtins import range
 from unittest import TestCase
+from pytest import raises
 from pydmd.cdmd import CDMD
 import matplotlib.pyplot as plt
 import numpy as np
@@ -315,6 +316,42 @@ class TestCDmd(TestCase):
 
         assert dmd.modes.shape[1] == old_n_modes - 2
         np.testing.assert_almost_equal(dmd.modes, retained_modes)
+
+    def test_getitem_modes(self):
+        dmd = CDMD(compression_matrix='normal', svd_rank=10)
+        dmd.fit(X=sample_data)
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[[1,3]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[2].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        dmd = CDMD(compression_matrix='normal')
+        dmd.fit(X=sample_data)
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]
 
     def test_reconstructed_data(self):
         dmd = CDMD(compression_matrix='normal')

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -643,3 +643,39 @@ class TestDmd(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    def test_getitem_modes(self):
+        dmd = DMD(svd_rank=-1)
+        dmd.fit(X=sample_data)
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[[1,3]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[2].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        dmd = DMD(svd_rank=-1)
+        dmd.fit(X=sample_data)
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]

--- a/tests/test_dmdc.py
+++ b/tests/test_dmdc.py
@@ -174,3 +174,36 @@ class TestDMDC(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    def test_getitem_modes(self):
+        system = create_system_with_B()
+        dmd = DMDc(svd_rank=-1)
+        dmd.fit(system['snapshots'], system['u'], system['B'])
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[1].modes), dmd.modes[:,1])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        system = create_system_with_B()
+        dmd = DMDc(svd_rank=-1)
+        dmd.fit(system['snapshots'], system['u'], system['B'])
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]

--- a/tests/test_fbdmd.py
+++ b/tests/test_fbdmd.py
@@ -180,3 +180,39 @@ class TestFbDmd(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    def test_getitem_modes(self):
+        dmd = FbDMD(svd_rank=-1)
+        dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[[1,3]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[2].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        dmd = FbDMD(svd_rank=-1)
+        dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]

--- a/tests/test_hankeldmd.py
+++ b/tests/test_hankeldmd.py
@@ -553,3 +553,39 @@ class TestHankelDmd(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    def test_getitem_modes(self):
+        dmd = HankelDMD(svd_rank=-1, d=5)
+        dmd.fit(X=sample_data)
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[[1,3]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[2].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        dmd = HankelDMD(svd_rank=-1, d=5)
+        dmd.fit(X=sample_data)
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -436,3 +436,39 @@ class TestHODmd(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    def test_getitem_modes(self):
+        dmd = HODMD(svd_rank=-1, d=5)
+        dmd.fit(X=sample_data)
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[[1,3]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[2].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        dmd = HODMD(svd_rank=-1, d=5)
+        dmd.fit(X=sample_data)
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -319,3 +319,9 @@ def test_bitmask_not_implemented():
         mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
         mrdmd.fit(X=sample_data)
         mrdmd.modes_activation_bitmask = None
+
+def test_getitem_not_implemented():
+    with raises(RuntimeError):
+        mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
+        mrdmd.fit(X=sample_data)
+        mrdmd[1:3]

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from past.utils import old_div
-from unittest import TestCase
+from pytest import raises
 from pydmd.mrdmd import MrDMD
 from pydmd import DMD
 import matplotlib.pyplot as plt
@@ -36,278 +36,286 @@ def create_data(t_size=1600):
 
 sample_data = create_data()
 
+def test_max_level_threshold():
+    level = 10
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    lvl_threshold = int(np.log(sample_data.shape[1]/4.)/np.log(2.)) + 1
+    assert lvl_threshold == mrdmd.max_level
 
-class TestMrDmd(TestCase):
-    def test_max_level_threshold(self):
-        level = 10
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        lvl_threshold = int(np.log(sample_data.shape[1]/4.)/np.log(2.)) + 1
-        assert lvl_threshold == mrdmd.max_level
+def test_partial_time_interval():
+    level = 4
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    ans = {'t0': 1200, 'tend': 1400.0, 'delta': 200.0}
+    assert mrdmd.partial_time_interval(3, 6) == ans
 
-    def test_partial_time_interval(self):
-        level = 4
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        ans = {'t0': 1200, 'tend': 1400.0, 'delta': 200.0}
-        assert mrdmd.partial_time_interval(3, 6) == ans
+def test_partial_time_interval2():
+    level = 4
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    with raises(ValueError):
+        mrdmd.partial_time_interval(5, 0)
 
-    def test_partial_time_interval2(self):
-        level = 4
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            mrdmd.partial_time_interval(5, 0)
+def test_partial_time_interval3():
+    level = 4
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    with raises(ValueError):
+        mrdmd.partial_time_interval(3, 8)
 
-    def test_partial_time_interval3(self):
-        level = 4
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            mrdmd.partial_time_interval(3, 8)
+def test_time_window_bins():
+    level = 4
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    assert len(mrdmd.time_window_bins(0, 1600)) == 2**5-1
 
-    def test_time_window_bins(self):
-        level = 4
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        assert len(mrdmd.time_window_bins(0, 1600)) == 2**5-1
-
-    def test_time_window_bins2(self):
-        level = 3
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        expected_bins = np.array([
-            [0, 0],
-            [1, 0],
-            [2, 0],
-            [2, 1],
-            [3, 1],
-            [3, 2]])
-        np.testing.assert_array_equal(mrdmd.time_window_bins(200, 600), expected_bins)
+def test_time_window_bins2():
+    level = 3
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    expected_bins = np.array([
+        [0, 0],
+        [1, 0],
+        [2, 0],
+        [2, 1],
+        [3, 1],
+        [3, 2]])
+    np.testing.assert_array_equal(mrdmd.time_window_bins(200, 600), expected_bins)
 
 
-    def test_time_window_eigs(self):
-        level = 2
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        exp =  sum([len(dmd.eigs) for dmd in mrdmd])
-        assert len(mrdmd.time_window_eigs(0, 1600)) == exp
+def test_time_window_eigs():
+    level = 2
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    exp =  sum([len(dmd.eigs) for dmd in mrdmd])
+    assert len(mrdmd.time_window_eigs(0, 1600)) == exp
 
-    def test_time_window_frequency(self):
-        level = 2
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        exp =  sum([len(dmd.frequency) for dmd in mrdmd])
-        assert len(mrdmd.time_window_frequency(0, 1600)) == exp
+def test_time_window_frequency():
+    level = 2
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    exp =  sum([len(dmd.frequency) for dmd in mrdmd])
+    assert len(mrdmd.time_window_frequency(0, 1600)) == exp
 
-    def test_time_window_growth_rate(self):
-        level = 2
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        exp =  sum([len(dmd.growth_rate) for dmd in mrdmd])
-        assert len(mrdmd.time_window_growth_rate(0, 1600)) == exp
+def test_time_window_growth_rate():
+    level = 2
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    exp =  sum([len(dmd.growth_rate) for dmd in mrdmd])
+    assert len(mrdmd.time_window_growth_rate(0, 1600)) == exp
 
-    def test_time_window_amplitudes(self):
-        level = 2
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        exp =  sum([len(dmd.amplitudes) for dmd in mrdmd])
-        assert len(mrdmd.time_window_amplitudes(0, 1600)) == exp
+def test_time_window_amplitudes():
+    level = 2
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    exp =  sum([len(dmd.amplitudes) for dmd in mrdmd])
+    assert len(mrdmd.time_window_amplitudes(0, 1600)) == exp
 
-    def test_shape_modes(self):
-        level = 2
-        dmd = DMD(svd_rank=1)
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        assert mrdmd.modes.shape == (sample_data.shape[0], 2**(level+1) - 1)
+def test_shape_modes():
+    level = 2
+    dmd = DMD(svd_rank=1)
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    assert mrdmd.modes.shape == (sample_data.shape[0], 2**(level+1) - 1)
 
-    def test_shape_dynamics(self):
-        level = 2
-        dmd = DMD(svd_rank=1)
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        assert mrdmd.dynamics.shape == (2**(level+1) - 1, sample_data.shape[1])
+def test_shape_dynamics():
+    level = 2
+    dmd = DMD(svd_rank=1)
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    assert mrdmd.dynamics.shape == (2**(level+1) - 1, sample_data.shape[1])
 
-    def test_reconstructed_data(self):
-        dmd = DMD(svd_rank=1)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        dmd_data = mrdmd.reconstructed_data
-        norm_err = (old_div(
-            np.linalg.norm(sample_data - dmd_data),
-            np.linalg.norm(sample_data)))
-        assert norm_err < 1
+def test_reconstructed_data():
+    dmd = DMD(svd_rank=1)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    dmd_data = mrdmd.reconstructed_data
+    norm_err = (old_div(
+        np.linalg.norm(sample_data - dmd_data),
+        np.linalg.norm(sample_data)))
+    assert norm_err < 1
 
-    def test_partial_modes1(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        pmodes = mrdmd.partial_modes(level)
-        assert pmodes.shape == (sample_data.shape[0], 2**level * rank)
+def test_partial_modes1():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pmodes = mrdmd.partial_modes(level)
+    assert pmodes.shape == (sample_data.shape[0], 2**level * rank)
 
-    def test_partial_modes2(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        pmodes = mrdmd.partial_modes(level, 3)
-        assert pmodes.shape == (sample_data.shape[0], rank)
+def test_partial_modes2():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pmodes = mrdmd.partial_modes(level, 3)
+    assert pmodes.shape == (sample_data.shape[0], rank)
 
-    def test_partial_dynamics1(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        pdynamics = mrdmd.partial_dynamics(level)
-        assert pdynamics.shape == (2**level * rank, sample_data.shape[1])
+def test_partial_dynamics1():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pdynamics = mrdmd.partial_dynamics(level)
+    assert pdynamics.shape == (2**level * rank, sample_data.shape[1])
 
-    def test_partial_dynamics2(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        pdynamics = mrdmd.partial_dynamics(level, 3)
-        assert pdynamics.shape == (rank, sample_data.shape[1] // 2**level)
+def test_partial_dynamics2():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pdynamics = mrdmd.partial_dynamics(level, 3)
+    assert pdynamics.shape == (rank, sample_data.shape[1] // 2**level)
 
-    def test_eigs2(self):
-        max_level = 5
-        level = 2
-        rank = -1
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        assert mrdmd.eigs.ndim == 1
+def test_eigs2():
+    max_level = 5
+    level = 2
+    rank = -1
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    assert mrdmd.eigs.ndim == 1
 
-    def test_partial_eigs1(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        peigs = mrdmd.partial_eigs(level)
-        assert peigs.shape == (rank * 2**level, )
+def test_partial_eigs1():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    peigs = mrdmd.partial_eigs(level)
+    assert peigs.shape == (rank * 2**level, )
 
-    def test_partial_eigs2(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        peigs = mrdmd.partial_eigs(level, 3)
-        assert peigs.shape == (rank, )
+def test_partial_eigs2():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    peigs = mrdmd.partial_eigs(level, 3)
+    assert peigs.shape == (rank, )
 
-    def test_partial_reconstructed1(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        pdata = mrdmd.partial_reconstructed_data(level)
-        assert pdata.shape == sample_data.shape
+def test_partial_reconstructed1():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pdata = mrdmd.partial_reconstructed_data(level)
+    assert pdata.shape == sample_data.shape
 
-    def test_partial_reconstructed2(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        pdata = mrdmd.partial_reconstructed_data(level, 3)
-        assert pdata.shape == (sample_data.shape[0], sample_data.shape[1] // 2**level)
+def test_partial_reconstructed2():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pdata = mrdmd.partial_reconstructed_data(level, 3)
+    assert pdata.shape == (sample_data.shape[0], sample_data.shape[1] // 2**level)
 
-    def test_wrong_partial_reconstructed(self):
-        max_level = 5
-        level = 2
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            pdata = mrdmd.partial_reconstructed_data(max_level+1, 2)
+def test_wrong_partial_reconstructed():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    with raises(ValueError):
+        pdata = mrdmd.partial_reconstructed_data(max_level+1, 2)
 
-    def test_wrong_level(self):
-        max_level = 5
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            mrdmd.partial_modes(max_level + 1)
+def test_wrong_level():
+    max_level = 5
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    with raises(ValueError):
+        mrdmd.partial_modes(max_level + 1)
 
-    def test_wrong_bin(self):
-        max_level = 5
-        level = 2
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            mrdmd.partial_modes(level=level, node=2**level)
+def test_wrong_bin():
+    max_level = 5
+    level = 2
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    with raises(ValueError):
+        mrdmd.partial_modes(level=level, node=2**level)
 
-    def test_wrong_plot_eig1(self):
-        rank = 2
-        dmd = DMD(svd_rank=rank)
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            mrdmd.plot_eigs(
-                show_axes=True, show_unit_circle=True, figsize=(8, 8), level=7)
+def test_wrong_plot_eig1():
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    with raises(ValueError):
+        mrdmd.plot_eigs(
+            show_axes=True, show_unit_circle=True, figsize=(8, 8), level=7)
 
-    def test_plot_eig1(self):
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        mrdmd.plot_eigs(show_axes=True, show_unit_circle=True, figsize=(8, 8))
-        plt.close()
+def test_plot_eig1():
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    mrdmd.plot_eigs(show_axes=True, show_unit_circle=True, figsize=(8, 8))
+    plt.close()
 
-    def test_plot_eig2(self):
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        mrdmd.plot_eigs(show_axes=True, show_unit_circle=False, title='Title')
-        plt.close()
+def test_plot_eig2():
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    mrdmd.plot_eigs(show_axes=True, show_unit_circle=False, title='Title')
+    plt.close()
 
-    def test_plot_eig3(self):
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
-        mrdmd.fit(X=sample_data)
-        mrdmd.plot_eigs(show_axes=False, show_unit_circle=False, level=1, node=0)
-        plt.close()
+def test_plot_eig3():
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    mrdmd.plot_eigs(show_axes=False, show_unit_circle=False, level=1, node=0)
+    plt.close()
 
-    def test_consistency(self):
-        level = 5
-        dmd = DMD()
-        mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
-        mrdmd.fit(X=sample_data)
-        np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)
+def test_consistency():
+    level = 5
+    dmd = DMD()
+    mrdmd = MrDMD(dmd, max_level=level, max_cycles=1)
+    mrdmd.fit(X=sample_data)
+    np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)
 
-    def test_consistency2(self):
-        import sys
-        import numpy
-        numpy.set_printoptions(threshold=sys.maxsize)
+def test_consistency2():
+    import sys
+    import numpy
+    numpy.set_printoptions(threshold=sys.maxsize)
 
+    mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
+    mrdmd.fit(X=create_data(t_size=1400))
+
+    np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)
+
+def test_bitmask_not_implemented():
+    with raises(RuntimeError):
         mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
-        mrdmd.fit(X=create_data(t_size=1400))
-
-        np.testing.assert_array_almost_equal(mrdmd.reconstructed_data, mrdmd.modes @ mrdmd.dynamics)
+        mrdmd.fit(X=sample_data)
+        mrdmd.modes_activation_bitmask
+    with raises(RuntimeError):
+        mrdmd = MrDMD(DMD(), max_level=5, max_cycles=1)
+        mrdmd.fit(X=sample_data)
+        mrdmd.modes_activation_bitmask = None

--- a/tests/test_optdmd.py
+++ b/tests/test_optdmd.py
@@ -1,5 +1,5 @@
 from builtins import range
-from unittest import TestCase
+from pytest import raises
 from pydmd.optdmd import OptDMD
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,64 +32,63 @@ def create_noisy_data():
 noisy_data = create_noisy_data()
 
 
-class TestOptDmd(TestCase):
-    def test_shape_1(self):
-        optdmd = OptDMD(svd_rank=-1)
-        optdmd.fit(X=sample_data)
-        assert optdmd.modes.shape[1] == sample_data.shape[1] - 1
+def test_shape_1():
+    optdmd = OptDMD(svd_rank=-1)
+    optdmd.fit(X=sample_data)
+    assert optdmd.modes.shape[1] == sample_data.shape[1] - 1
 
-    def test_shape_2(self):
-        optdmd = OptDMD(svd_rank=-1)
-        optdmd.fit(X=sample_data[:, :-1], Y=sample_data[:, 1:])
-        assert optdmd.modes.shape[1] == sample_data.shape[1]-1
+def test_shape_2():
+    optdmd = OptDMD(svd_rank=-1)
+    optdmd.fit(X=sample_data[:, :-1], Y=sample_data[:, 1:])
+    assert optdmd.modes.shape[1] == sample_data.shape[1]-1
 
-    def test_truncation_shape(self):
-        optdmd = OptDMD(svd_rank=3)
-        optdmd.fit(X=sample_data)
-        assert optdmd.modes.shape[1] == 3
+def test_truncation_shape():
+    optdmd = OptDMD(svd_rank=3)
+    optdmd.fit(X=sample_data)
+    assert optdmd.modes.shape[1] == 3
 
-    def test_rank(self):
-        optdmd = OptDMD(svd_rank=0.9)
-        optdmd.fit(X=sample_data)
-        assert len(optdmd.eigs) == 2
+def test_rank():
+    optdmd = OptDMD(svd_rank=0.9)
+    optdmd.fit(X=sample_data)
+    assert len(optdmd.eigs) == 2
 
-    def test_Atilde_shape(self):
-        optdmd = OptDMD(svd_rank=3)
-        optdmd.fit(X=sample_data)
-        assert optdmd.atilde.shape == (optdmd.svd_rank, optdmd.svd_rank)
+def test_Atilde_shape():
+    optdmd = OptDMD(svd_rank=3)
+    optdmd.fit(X=sample_data)
+    assert optdmd.atilde.shape == (optdmd.svd_rank, optdmd.svd_rank)
 
-    def test_Atilde_values(self):
-        optdmd = OptDMD(svd_rank=2)
-        optdmd.fit(X=sample_data)
-        exact_atilde = np.array(
-            [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
-             [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
-        np.testing.assert_allclose(np.linalg.eigvals(exact_atilde), np.linalg.eigvals(optdmd.atilde))
+def test_Atilde_values():
+    optdmd = OptDMD(svd_rank=2)
+    optdmd.fit(X=sample_data)
+    exact_atilde = np.array(
+        [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
+            [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
+    np.testing.assert_allclose(np.linalg.eigvals(exact_atilde), np.linalg.eigvals(optdmd.atilde))
 
-    def test_eigs_1(self):
-        optdmd = OptDMD(svd_rank=-1)
-        optdmd.fit(X=sample_data)
-        assert len(optdmd.eigs) == 14
+def test_eigs_1():
+    optdmd = OptDMD(svd_rank=-1)
+    optdmd.fit(X=sample_data)
+    assert len(optdmd.eigs) == 14
 
-    def test_eigs_2(self):
-        optdmd = OptDMD(svd_rank=5)
-        optdmd.fit(X=sample_data)
-        assert len(optdmd.eigs) == 5
+def test_eigs_2():
+    optdmd = OptDMD(svd_rank=5)
+    optdmd.fit(X=sample_data)
+    assert len(optdmd.eigs) == 5
 
-    def test_eigs_3(self):
-        optdmd = OptDMD(svd_rank=2)
-        optdmd.fit(X=sample_data)
-        expected_eigs = np.array([
-            -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
-        ])
-        np.testing.assert_almost_equal(optdmd.eigs, expected_eigs, decimal=6)
+def test_eigs_3():
+    optdmd = OptDMD(svd_rank=2)
+    optdmd.fit(X=sample_data)
+    expected_eigs = np.array([
+        -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
+    ])
+    np.testing.assert_almost_equal(optdmd.eigs, expected_eigs, decimal=6)
 
-    # def test_dynamics_1(self):
+    # def test_dynamics_1():
     #     dmd = DMD(svd_rank=5)
     #     dmd.fit(X=sample_data)
     #     assert dmd.dynamics.shape == (5, sample_data.shape[1])
     #
-    # def test_dynamics_2(self):
+    # def test_dynamics_2():
     #     dmd = DMD(svd_rank=1)
     #     dmd.fit(X=sample_data)
     #     expected_dynamics = np.array([[
@@ -104,12 +103,12 @@ class TestOptDmd(TestCase):
     #     ]])
     #     np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
     #
-    # def test_dynamics_opt_1(self):
+    # def test_dynamics_opt_1():
     #     dmd = DMD(svd_rank=5, opt=True)
     #     dmd.fit(X=sample_data)
     #     assert dmd.dynamics.shape == (5, sample_data.shape[1])
     #
-    # def test_dynamics_opt_2(self):
+    # def test_dynamics_opt_2():
     #     dmd = DMD(svd_rank=1, opt=True)
     #     dmd.fit(X=sample_data)
     #     expected_dynamics = np.array([[
@@ -124,31 +123,31 @@ class TestOptDmd(TestCase):
     #     ]])
     #     np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
 
-    # def test_reconstructed_data(self):
+    # def test_reconstructed_data():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
     #     dmd_data = dmd.reconstructed_data
     #     np.testing.assert_allclose(dmd_data, sample_data)
 
-    # def test_original_time(self):
+    # def test_original_time():
     #     dmd = DMD(svd_rank=2)
     #     dmd.fit(X=sample_data)
     #     expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
     #     np.testing.assert_equal(dmd.original_time, expected_dict)
     #
-    # def test_original_timesteps(self):
+    # def test_original_timesteps():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
     #     np.testing.assert_allclose(dmd.original_timesteps,
     #                                np.arange(sample_data.shape[1]))
     #
-    # def test_dmd_time_1(self):
+    # def test_dmd_time_1():
     #     dmd = DMD(svd_rank=2)
     #     dmd.fit(X=sample_data)
     #     expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
     #     np.testing.assert_equal(dmd.dmd_time, expected_dict)
     #
-    # def test_dmd_time_2(self):
+    # def test_dmd_time_2():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
     #     dmd.dmd_time['t0'] = 10
@@ -156,7 +155,7 @@ class TestOptDmd(TestCase):
     #     expected_data = sample_data[:, -5:]
     #     np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
     #
-    # def test_dmd_time_3(self):
+    # def test_dmd_time_3():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
     #     dmd.dmd_time['t0'] = 8
@@ -164,7 +163,7 @@ class TestOptDmd(TestCase):
     #     expected_data = sample_data[:, 8:12]
     #     np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
     #
-    # def test_dmd_time_4(self):
+    # def test_dmd_time_4():
     #     dmd = DMD(svd_rank=3)
     #     dmd.fit(X=sample_data)
     #     dmd.dmd_time['t0'] = 20
@@ -174,86 +173,96 @@ class TestOptDmd(TestCase):
     #                               [3.38410649e-83 + 3.75677740e-83j]])
     #     np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
     #
-    # def test_plot_eigs_1(self):
+    # def test_plot_eigs_1():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
     #     dmd.plot_eigs(show_axes=True, show_unit_circle=True)
     #     plt.close()
     #
-    # def test_plot_eigs_2(self):
+    # def test_plot_eigs_2():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
     #     dmd.plot_eigs(show_axes=False, show_unit_circle=False)
     #     plt.close()
     #
-    # def test_plot_modes_1(self):
+    # def test_plot_modes_1():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
-    #     with self.assertRaises(ValueError):
+    #     with raises(ValueError):
     #         dmd.plot_modes_2D()
     #
-    # def test_plot_modes_2(self):
+    # def test_plot_modes_2():
     #     dmd = DMD(svd_rank=-1)
     #     dmd.fit(X=sample_data)
     #     dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
     #     plt.close()
     #
-    # def test_plot_modes_3(self):
+    # def test_plot_modes_3():
     #     dmd = DMD()
     #     snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
     #     dmd.fit(X=snapshots)
     #     dmd.plot_modes_2D()
     #     plt.close()
     #
-    # def test_plot_modes_4(self):
+    # def test_plot_modes_4():
     #     dmd = DMD()
     #     snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
     #     dmd.fit(X=snapshots)
     #     dmd.plot_modes_2D(index_mode=1)
     #     plt.close()
     #
-    # def test_plot_modes_5(self):
+    # def test_plot_modes_5():
     #     dmd = DMD()
     #     snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
     #     dmd.fit(X=snapshots)
     #     dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
-    #     self.addCleanup(os.remove, 'tmp.1.png')
+    #     .addCleanup(os.remove, 'tmp.1.png')
     #
-    # def test_plot_snapshots_1(self):
+    # def test_plot_snapshots_1():
     #     dmd = DMD()
     #     dmd.fit(X=sample_data)
-    #     with self.assertRaises(ValueError):
+    #     with raises(ValueError):
     #         dmd.plot_snapshots_2D()
     #
-    # def test_plot_snapshots_2(self):
+    # def test_plot_snapshots_2():
     #     dmd = DMD(svd_rank=-1)
     #     dmd.fit(X=sample_data)
     #     dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
     #     plt.close()
     #
-    # def test_plot_snapshots_3(self):
+    # def test_plot_snapshots_3():
     #     dmd = DMD()
     #     snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
     #     dmd.fit(X=snapshots)
     #     dmd.plot_snapshots_2D()
     #     plt.close()
     #
-    # def test_plot_snapshots_4(self):
+    # def test_plot_snapshots_4():
     #     dmd = DMD()
     #     snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
     #     dmd.fit(X=snapshots)
     #     dmd.plot_snapshots_2D(index_snap=2)
     #     plt.close()
     #
-    # def test_plot_snapshots_5(self):
+    # def test_plot_snapshots_5():
     #     dmd = DMD()
     #     snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
     #     dmd.fit(X=snapshots)
     #     dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
-    #     self.addCleanup(os.remove, 'tmp.2.png')
+    #     .addCleanup(os.remove, 'tmp.2.png')
     #
-    # def test_tdmd_plot(self):
+    # def test_tdmd_plot():
     #     dmd = DMD(tlsq_rank=3)
     #     dmd.fit(X=sample_data)
     #     dmd.plot_eigs(show_axes=False, show_unit_circle=False)
     #     plt.close()
+
+def test_bitmask_not_implemented():
+    with raises(RuntimeError):
+        optdmd = OptDMD(svd_rank=2)
+        optdmd.fit(X=sample_data)
+        optdmd.modes_activation_bitmask
+    with raises(RuntimeError):
+        optdmd = OptDMD(svd_rank=2)
+        optdmd.fit(X=sample_data)
+        optdmd.modes_activation_bitmask = None

--- a/tests/test_optdmd.py
+++ b/tests/test_optdmd.py
@@ -266,3 +266,9 @@ def test_bitmask_not_implemented():
         optdmd = OptDMD(svd_rank=2)
         optdmd.fit(X=sample_data)
         optdmd.modes_activation_bitmask = None
+
+def test_getitem_not_implemented():
+    with raises(RuntimeError):
+        optdmd = OptDMD(svd_rank=2)
+        optdmd.fit(X=sample_data)
+        optdmd[1:3]

--- a/tests/test_spdmd.py
+++ b/tests/test_spdmd.py
@@ -249,3 +249,39 @@ class TestSpDmd(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    def test_getitem_modes(self):
+        dmd = SpDMD(release_memory=True, svd_rank=-1)
+        dmd.fit(X=data)
+        old_n_modes = dmd.modes.shape[1]
+
+        assert dmd[[0,-1]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[[1,3]].modes.shape[1] == 2
+        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+        assert dmd[2].modes.shape[1] == 1
+        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+        assert dmd.modes.shape[1] == old_n_modes
+
+    def test_getitem_raises(self):
+        dmd = SpDMD(release_memory=True, svd_rank=-1)
+        dmd.fit(X=data)
+
+        with self.assertRaises(ValueError):
+            dmd[[0,1,1,0,1]]
+        with self.assertRaises(ValueError):
+            dmd[[True, True, False, True]]
+        with self.assertRaises(ValueError):
+            dmd[1.0]


### PR DESCRIPTION
In this PR I implemented the subscripting operator `[]` for subclasses (not all) of `DMDBase`. Subscripting can be used to select a subset of DMD modes and test the results on that subset. It's basically a more comfortable interface to the property `modes_activation_bitmask` introduced in #245.

`MrDMD` and `OptDMD` are not supported at the moment since they work differently than their siblings.

The subscripting operator allows indexing DMD modes using:
- slices (`start:end:step`);
- scalar index;
- multiple indexes (`[0,2,3,...]`)

Example:
```python
# plotting different results using different subsets of DMD modes
dmd = ...

plt.subplot(1,3,1)
plt.pcolormesh(dmd.reconstructed_data)

plt.subplot(1,3,2)
plt.pcolormesh(dmd[:5].reconstructed_data)

plt.subplot(1,3,3)
plt.pcolormesh(dmd[5::2].reconstructed_data)
```

The implementation uses `modes_activation_bitmask` under the hood, along with a shallow copy of the instance in order to avoid polluting the original value of `modes_activation_bitmask`. Subscripting returns a new DMD instance such that assignments are not reflected into the original instance. However this does not hold for NumPy arrays, which are _views_ on the arrays of the original DMD instance. For this reason low-level modifications on DMD modes should be avoided. 