### PR TITLE
[ModesTuner] Introduce parameter `nullify_amplitudes`

### DIFF
--- a/pydmd/__init__.py
+++ b/pydmd/__init__.py
@@ -17,3 +17,4 @@ from .dmdc import DMDc
 from .optdmd import OptDMD
 from .spdmd import SpDMD
 from .paramdmd import ParametricDMD
+from .dmd_modes_tuner import ModesTuner

--- a/pydmd/cdmd.py
+++ b/pydmd/cdmd.py
@@ -154,14 +154,14 @@ class CDMD(DMDBase):
         self._opt = opt
         self._compression_matrix = compression_matrix
 
-        self._modes_activation_bitmask = None
-
         self._Atilde = CDMDOperator(svd_rank=svd_rank,
                                     rescale_mode=rescale_mode,
                                     forward_backward=forward_backward,
                                     sorted_eigs=sorted_eigs,
                                     tikhonov_regularization=
                                     tikhonov_regularization)
+
+        self._modes_activation_bitmask_proxy = None
 
     @property
     def compression_matrix(self):

--- a/pydmd/dmd_modes_tuner.py
+++ b/pydmd/dmd_modes_tuner.py
@@ -66,27 +66,10 @@ def select_modes(
     all_indexes = set(np.arange(len(dmd.eigs)))
     cut_indexes = np.array(list(all_indexes - set(selected_indexes)))
 
-    if nullify_amplitudes:
-        dmd._b[cut_indexes] = 0
-    else:
-        dmd.operator._eigenvalues = dmd.operator._eigenvalues[selected_indexes]
-        dmd.operator._Lambda = dmd.operator._Lambda[selected_indexes]
-
-        dmd.operator._eigenvectors = dmd.operator._eigenvectors[
-            :, selected_indexes
-        ]
-        dmd.operator._modes = dmd.operator._modes[:, selected_indexes]
-
-        # TODO: should improve this [code repetition]
-        dmd.operator._Atilde = np.linalg.multi_dot(
-            [
-                dmd.operator._eigenvectors,
-                np.diag(dmd.operator._eigenvalues),
-                np.linalg.pinv(dmd.operator._eigenvectors),
-            ]
-        )
-
-        dmd._b = dmd._b[selected_indexes]
+    if len(cut_indexes) > 0:
+        tmp = np.array(dmd.modes_activation_bitmask)
+        tmp[cut_indexes] = False
+        dmd.modes_activation_bitmask = tmp
 
     if return_indexes:
         return dmd, cut_indexes
@@ -145,14 +128,13 @@ def stabilize_modes(
         eigs_module < outer_radius,
     )
 
-    dmd._b[fixable_eigs_indexes] *= np.abs(dmd.eigs[fixable_eigs_indexes])
-    dmd.operator._eigenvalues[fixable_eigs_indexes] /= np.abs(
+    dmd.amplitudes[fixable_eigs_indexes] *= np.abs(
         dmd.eigs[fixable_eigs_indexes]
     )
-
-    stabilized_indexes = np.where(fixable_eigs_indexes)[0]
+    dmd.eigs[fixable_eigs_indexes] /= np.abs(dmd.eigs[fixable_eigs_indexes])
 
     if return_indexes:
+        stabilized_indexes = np.where(fixable_eigs_indexes)[0]
         return dmd, stabilized_indexes
     return dmd
 

--- a/pydmd/dmd_modes_tuner.py
+++ b/pydmd/dmd_modes_tuner.py
@@ -8,7 +8,13 @@ from functools import partial
 import numpy as np
 
 
-def select_modes(dmd, criteria, in_place=True, return_indexes=False):
+def select_modes(
+    dmd,
+    criteria,
+    in_place=True,
+    return_indexes=False,
+    nullify_amplitudes=False,
+):
     """
     Select the DMD modes by using the given `criteria`.
     `criteria` is a function which takes as input the DMD
@@ -39,6 +45,10 @@ def select_modes(dmd, criteria, in_place=True, return_indexes=False):
     :param bool return_indexes: If `True`, this function returns the indexes
         corresponding to DMD modes cut using the given `criteria` (default
         `False`).
+    :param bool nullify_amplitudes: If `True`, the amplitudes associated with
+        DMD modes to be removed are set to 0, therefore the number of DMD
+        modes remains constant. If `False` (default) DMD modes are actually
+        removed, therefore the number of DMD modes in the instance decreases.
     :returns: If `return_indexes` is `True`, the returned value is a tuple
         whose items are:
 
@@ -56,24 +66,27 @@ def select_modes(dmd, criteria, in_place=True, return_indexes=False):
     all_indexes = set(np.arange(len(dmd.eigs)))
     cut_indexes = np.array(list(all_indexes - set(selected_indexes)))
 
-    dmd.operator._eigenvalues = dmd.operator._eigenvalues[selected_indexes]
-    dmd.operator._Lambda = dmd.operator._Lambda[selected_indexes]
+    if nullify_amplitudes:
+        dmd._b[cut_indexes] = 0
+    else:
+        dmd.operator._eigenvalues = dmd.operator._eigenvalues[selected_indexes]
+        dmd.operator._Lambda = dmd.operator._Lambda[selected_indexes]
 
-    dmd.operator._eigenvectors = dmd.operator._eigenvectors[
-        :, selected_indexes
-    ]
-    dmd.operator._modes = dmd.operator._modes[:, selected_indexes]
-
-    # TODO: should improve this [code repetition]
-    dmd.operator._Atilde = np.linalg.multi_dot(
-        [
-            dmd.operator._eigenvectors,
-            np.diag(dmd.operator._eigenvalues),
-            np.linalg.pinv(dmd.operator._eigenvectors),
+        dmd.operator._eigenvectors = dmd.operator._eigenvectors[
+            :, selected_indexes
         ]
-    )
+        dmd.operator._modes = dmd.operator._modes[:, selected_indexes]
 
-    dmd._b = dmd._compute_amplitudes()
+        # TODO: should improve this [code repetition]
+        dmd.operator._Atilde = np.linalg.multi_dot(
+            [
+                dmd.operator._eigenvectors,
+                np.diag(dmd.operator._eigenvalues),
+                np.linalg.pinv(dmd.operator._eigenvectors),
+            ]
+        )
+
+        dmd._b = dmd._b[selected_indexes]
 
     if return_indexes:
         return dmd, cut_indexes
@@ -452,7 +465,7 @@ class ModesTuner:
             return list(map(deepcopy, self._dmds))
         return deepcopy(self._dmds[0])
 
-    def select(self, criteria, **kwargs):
+    def select(self, criteria, nullify_amplitudes=False, **kwargs):
         r"""
         Select the DMD modes by using the given `criteria`, which can be either
         a string or a function. You can choose pre-packed criteria by passing
@@ -484,8 +497,15 @@ class ModesTuner:
             If `criteria` is a function it must take an instance of DMD as the
             only parameter.
         :type criteria: str or callable
+        :param bool nullify_amplitudes: If `True`, the amplitudes associated
+            with DMD modes to be removed are set to 0, therefore the number of
+            DMD modes remains constant. If `False` (default) DMD modes are
+            actually removed, therefore the number of DMD modes in the instance
+            decreases.
         :param \**kwargs: Parameters passed to the chosen criteria (if
             `criteria` is a string).
+        :return ModesTuner: This instance of `ModesTuner` in order to allow
+            chaining multiple operations.
         """
 
         if isinstance(criteria, str):
@@ -499,7 +519,8 @@ modes (either a string or a function)"""
             )
 
         for dmd in self._dmds:
-            select_modes(dmd, criteria)
+            select_modes(dmd, criteria, nullify_amplitudes=nullify_amplitudes)
+        return self
 
     def stabilize(self, inner_radius, outer_radius=np.inf):
         """
@@ -525,7 +546,10 @@ modes (either a string or a function)"""
             be stabilized.
         :param float outer_radius: The outer radius of the circular sector to
             be stabilized.
+        :return ModesTuner: This instance of `ModesTuner` in order to allow
+            chaining multiple operations.
         """
 
         for dmd in self._dmds:
             stabilize_modes(dmd, inner_radius, outer_radius)
+        return self

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -8,7 +8,7 @@ from builtins import range
 from os.path import splitext
 import warnings
 import pickle
-from copy import copy
+from copy import copy, deepcopy
 
 import numpy as np
 import matplotlib as mpl
@@ -466,6 +466,10 @@ _set_initial_time_dictionary() has not been called, did you call fit()?"""
 _set_initial_time_dictionary() has not been called, did you call fit()?"""
             )
         return self._dmd_time
+
+    @dmd_time.setter
+    def dmd_time(self, value):
+        self._dmd_time = deepcopy(value)
 
     def _set_initial_time_dictionary(self, time_dict):
         """
@@ -1022,3 +1026,8 @@ class DMDTimeDict(dict):
                     key
                 )
             )
+
+    def __eq__(self, o):
+        if isinstance(o, dict):
+            return all(map(lambda s: o[s] == self[s], ['t0', 'tend', 'dt']))
+        return False

--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -20,6 +20,100 @@ from .dmdoperator import DMDOperator
 mpl.rcParams["figure.max_open_warning"] = 0
 
 
+class ActivationBitmaskProxy:
+    """
+    A proxy which stands in the middle between a bitmask and an instance of
+    :class:`DMDBase`. The proxy holds the original values of modes,
+    eigenvalues and amplitudes, and exposes (via
+    :func:`ActivationBitmaskProxy.modes`, :func:`ActivationBitmaskProxy.eigs`
+    and :func:`ActivationBitmaskProxy.amplitudes`) the proxied (i.e. filtered)
+    those quantities, depending on the current value of the
+    bitmask (see also :func:`ActivationBitmaskProxy.change_bitmask`).
+
+    This machinery is needed in order to allow for the modification of the
+    matrices containing modes, amplitudes and eigenvalues after the indexing
+    provided by the bitmask. Since double indexing in NumPy does not deliver a
+    modifiable view of the original array, we need to propagate any change
+    on the selection to the original matrices at some point: we decided to
+    propagate the changes just before a change in the bitmask, namely in the
+    last available moment before losing the information provided by the ``old''
+    bitmask.
+
+    :param modes: A matrix containing the original DMD modes.
+    :type modes: np.ndarray
+    :param eigs: An array containing the original DMD eigenvalues.
+    :type eigs: np.ndarray
+    :param amplitudes: An array containing the original DMD amplitudes.
+    :type amplitudes: np.ndarray
+    """
+
+    def __init__(self, modes, eigs, amplitudes):
+        self._original_modes = modes
+        self._original_eigs = eigs
+        self._original_amplitudes = amplitudes
+
+        self.old_bitmask = None
+        self.change_bitmask(np.full(len(eigs), True))
+
+    def change_bitmask(self, value):
+        """
+        Change the bitmask which regulates this proxy.
+
+        Before changing the bitmask this method reflects any change performed
+        on the proxied quantities provided by this proxy to the original values
+        of the quantities.
+
+        :param value: New value of the bitmask, represented by an array of
+            `bool` whose size is the same of the number of DMD modes.
+        :type value: np.ndarray
+        """
+
+        # apply changes made on the proxied values to the original values
+        if self.old_bitmask is not None:
+            self._original_modes[:, self.old_bitmask] = self.modes
+            self._original_eigs[self.old_bitmask] = self.eigs
+            self._original_amplitudes[self.old_bitmask] = self.amplitudes
+
+        self._modes = np.array(self._original_modes)[:, value]
+        self._eigs = np.array(self._original_eigs)[value]
+        self._amplitudes = np.array(self._original_amplitudes)[value]
+
+        self.old_bitmask = value
+
+    @property
+    def modes(self):
+        """
+        Proxied (i.e. filtered according to the bitmask) view on the matrix
+        of DMD modes.
+
+        :return: A matrix containing the selected DMD modes.
+        :rtype: np.ndarray
+        """
+        return self._modes
+
+    @property
+    def eigs(self):
+        """
+        Proxied (i.e. filtered according to the bitmask) view on the array
+        of DMD eigenvalues.
+
+        :return: An array containing the selected DMD eigenvalues.
+        :rtype: np.ndarray
+        """
+        return self._eigs
+
+    @property
+    def amplitudes(self):
+        """
+        Proxied (i.e. filtered according to the bitmask) view on the array
+        of DMD amplitudes.
+
+        :return: An array containing the selected DMD amplitudes.
+        :rtype: np.ndarray
+        """
+        return self._amplitudes
+
+
 class DMDBase(object):
     """
     Dynamic Mode Decomposition base class.
@@ -62,7 +156,7 @@ class DMDBase(object):
     :type sorted_eigs: {'real', 'abs'} or False
     :param tikhonov_regularization: Tikhonov parameter for the regularization.
         If `None`, no regularization is applied, if `float`, it is used as the
-        :math:`\lambda` tikhonov parameter.
+        :math:`\\lambda` tikhonov parameter.
     :type tikhonov_regularization: int or float
 
     :cvar dict original_time: dictionary that contains information about the
@@ -111,7 +205,7 @@ class DMDBase(object):
         self._snapshots = None
         self._snapshots_shape = None
 
-        self._modes_activation_bitmask = None
+        self._modes_activation_bitmask_proxy = None
 
     @property
     def opt(self):
@@ -165,6 +259,14 @@ class DMDBase(object):
             self.original_time["dt"],
         )
 
+    def allocate_proxy(self):
+        # if this is not true, this call is probably a sub-call of some
+        # get-access to self.modes (most likely in compute_amplitudes())
+        if hasattr(self, "_b") and self._b is not None:
+            self._modes_activation_bitmask_proxy = ActivationBitmaskProxy(
+                self.operator.modes, self.operator.eigenvalues, self._b
+            )
+
     @property
     def modes(self):
         """
@@ -173,7 +275,14 @@ class DMDBase(object):
         :return: the matrix containing the DMD modes.
         :rtype: numpy.ndarray
         """
-        return self.operator.modes[:, self.modes_activation_bitmask]
+        if self.fitted:
+            if not self._modes_activation_bitmask_proxy:
+                self.allocate_proxy()
+                # if the value is still None, it means that we cannot create
+                # the proxy at the moment
+                if not self._modes_activation_bitmask_proxy:
+                    return self.operator.modes
+            return self._modes_activation_bitmask_proxy.modes
 
     @property
     def atilde(self):
@@ -203,7 +312,14 @@ class DMDBase(object):
         :return: the eigenvalues from the eigendecomposition of `atilde`.
         :rtype: numpy.ndarray
         """
-        return self.operator.eigenvalues[self.modes_activation_bitmask]
+        if self.fitted:
+            if not self._modes_activation_bitmask_proxy:
+                self.allocate_proxy()
+                # if the value is still None, it means that we cannot create
+                # the proxy at the moment
+                if not self._modes_activation_bitmask_proxy:
+                    return self.operator.eigenvalues
+            return self._modes_activation_bitmask_proxy.eigs
 
     def _translate_eigs_exponent(self, tpow):
         """
@@ -311,7 +427,10 @@ class DMDBase(object):
         :return: the array that contains the amplitudes coefficient.
         :rtype: numpy.ndarray
         """
-        return self._b[self.modes_activation_bitmask]
+        if self.fitted:
+            if not self._modes_activation_bitmask_proxy:
+                self.allocate_proxy()
+            return self._modes_activation_bitmask_proxy.amplitudes
 
     @property
     def fitted(self):
@@ -336,15 +455,35 @@ class DMDBase(object):
         `modes_activation_bitmask` is an array of `True` values of the same
         shape of :func:`amplitudes`.
 
+        The array returned is read-only (this allow us to react appropriately
+        to changes in the bitmask). In order to modify the bitmask you need to
+        set the field to a brand-new value (see example below).
+
+        Example:
+
+        .. code-block:: python
+
+            >>> # this is an error
+            >>> dmd.modes_activation_bitmask[[1,2]] = False
+            ValueError: assignment destination is read-only
+            >>> tmp = np.array(dmd.modes_activation_bitmask)
+            >>> tmp[[1,2]] = False
+            >>> dmd.modes_activation_bitmask = tmp
+
         :return: The DMD modes activation bitmask.
         :rtype: numpy.ndarray
         """
         # check that the DMD was fitted
         if not self.fitted:
             raise RuntimeError("This DMD instance has not been fitted yet.")
-        if self._modes_activation_bitmask is None:
-            return np.full(self.operator.modes.shape[1], True, dtype=bool)
-        return self._modes_activation_bitmask
+
+        if not self._modes_activation_bitmask_proxy:
+            self.allocate_proxy()
+
+        bitmask = self._modes_activation_bitmask_proxy.old_bitmask
+        # make sure that the array is immutable
+        bitmask.flags.writeable = False
+        return bitmask
 
     @modes_activation_bitmask.setter
     def modes_activation_bitmask(self, value):
@@ -366,7 +505,7 @@ class DMDBase(object):
                 )
             )
 
-        self._modes_activation_bitmask = value
+        self._modes_activation_bitmask_proxy.change_bitmask(value)
 
     def __getitem__(self, key):
         """
@@ -395,23 +534,25 @@ class DMDBase(object):
             if isinstance(key, (list, np.ndarray)):
                 if not all(map(filter_function, key)):
                     raise ValueError(
-                        "Invalid argument type, expected a slice, an int, or a "
-                        "list of indexes."
+                        "Invalid argument type, expected a slice, an int, or "
+                        "a list of indexes."
                     )
                 # no repeated elements
                 if len(key) != len(set(key)):
                     raise ValueError("Repeated indexes are not supported.")
         else:
             raise ValueError(
-                "Invalid argument type, expected a slice, an int, or a list of "
-                "indexes, got {}".format(type(key))
+                "Invalid argument type, expected a slice, an int, or a list "
+                "of indexes, got {}".format(type(key))
             )
 
         mask = np.full(self.modes_activation_bitmask.shape, False)
         mask[key] = True
 
         shallow_copy = copy(self)
+        shallow_copy.allocate_proxy()
         shallow_copy.modes_activation_bitmask = mask
+
         return shallow_copy
 
     @property
@@ -713,7 +854,7 @@ matrix, or regularization methods.""".format(
         if self.eigs is None:
             raise ValueError(
                 "The eigenvalues have not been computed."
-                "You have to perform the fit method."
+                "You have to call the fit() method."
             )
 
         if dpi is not None:
@@ -1029,5 +1170,5 @@ class DMDTimeDict(dict):
 
     def __eq__(self, o):
         if isinstance(o, dict):
-            return all(map(lambda s: o[s] == self[s], ['t0', 'tend', 'dt']))
+            return all(map(lambda s: o[s] == self[s], ["t0", "tend", "dt"]))
         return False

--- a/pydmd/dmdc.py
+++ b/pydmd/dmdc.py
@@ -200,7 +200,7 @@ class DMDc(DMDBase):
         self._controlin_shape = None
         self._basis = None
 
-        self._modes_activation_bitmask = None
+        self._modes_activation_bitmask_proxy = None
 
     @property
     def svd_rank_omega(self):

--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -270,6 +270,10 @@ class HankelDMD(DMDBase):
         return self._sub_dmd.modes
 
     @property
+    def eigs(self):
+        return self._sub_dmd.eigs
+
+    @property
     def amplitudes(self):
         return self._sub_dmd.amplitudes
 
@@ -313,6 +317,8 @@ class HankelDMD(DMDBase):
         """
 
         sub_dmd_copy = copy(self._sub_dmd)
+        sub_dmd_copy.allocate_proxy()
+
         shallow_copy = copy(self)
         shallow_copy._sub_dmd = sub_dmd_copy
         return DMDBase.__getitem__(shallow_copy, key)

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -388,7 +388,6 @@ class MrDMD(DMDBase):
 
         X = self._snapshots.copy()
         for level in self.dmd_tree.levels:
-
             n_leaf = 2 ** level
             Xs = np.array_split(X, n_leaf, axis=1)
 

--- a/pydmd/paramdmd.py
+++ b/pydmd/paramdmd.py
@@ -67,14 +67,23 @@ class ParametricDMD:
     @property
     def dmd_time(self):
         """
-        The time dictionary used by this instance, which coincides with the
-        dictionary used by the reference of this instance (see
+        The time dictionary used by the reference DMD instance (see also
         :func:`_reference_dmd`).
 
-        :return: The time dictionary used by this instance.
-        :rtype: dict
+        :getter: Return the time dictionary used by the reference DMD instance.
+        :setter: Set the given time dictionary in the field `dmd_time` for all
+            DMD instances.
+        :type: pydmd.dmdbase.DMDTimeDict
         """
         return self._reference_dmd.dmd_time
+
+    @dmd_time.setter
+    def dmd_time(self, value):
+        if isinstance(self._dmd, list):
+            for dmd in self._dmd:
+                dmd.dmd_time = value
+        else:
+            self._reference_dmd.dmd_time = value
 
     @property
     def dmd_timesteps(self):
@@ -383,7 +392,7 @@ class ParametricDMD:
         >>> pdmd.fit(...)
         >>> pdmd.save('pydmd.pdmd')
         """
-        with open(fname, 'wb') as output:
+        with open(fname, "wb") as output:
             pickle.dump(self, output, pickle.HIGHEST_PROTOCOL)
 
     @staticmethod
@@ -399,11 +408,10 @@ class ParametricDMD:
         >>> pdmd = ParametricDMD.load('pydmd.pdmd')
         >>> print(pdmd.reconstructed_data)
         """
-        with open(fname, 'rb') as output:
+        with open(fname, "rb") as output:
             dmd = pickle.load(output)
 
         return dmd
-
 
     def _predict_modal_coefficients(self):
         """

--- a/pydmd/spdmd.py
+++ b/pydmd/spdmd.py
@@ -109,6 +109,8 @@ class SpDMD(DMD):
         self._q = None
         self._Plow = None
 
+        self._modes_activation_bitmask_proxy = None
+
     def fit(self, X):
         """
         Compute the Dynamic Modes Decomposition of the input data.
@@ -130,6 +132,9 @@ class SpDMD(DMD):
 
         # compute the (sparse) vector of optimal DMD amplitudes
         self._b = self._optimal_amplitudes(zero_amplitudes)
+        # re-allocate the Proxy to avoid problems due to the fact that we
+        # re-computed the amplitudes
+        self.allocate_proxy()
 
         # release memory
         if self._release_memory:

--- a/tests/test_cdmd.py
+++ b/tests/test_cdmd.py
@@ -363,3 +363,12 @@ class TestCDmd(TestCase):
 
         dmd.reconstructed_data
         assert True
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        dmd = CDMD(compression_matrix='normal')
+        dmd.fit(X=sample_data)
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -679,3 +679,12 @@ class TestDmd(TestCase):
             dmd[[True, True, False, True]]
         with self.assertRaises(ValueError):
             dmd[1.0]
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        dmd = DMD(svd_rank=-1)
+        dmd.fit(X=sample_data)
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_dmd_modes_tuner.py
+++ b/tests/test_dmd_modes_tuner.py
@@ -2,8 +2,10 @@ from pytest import raises
 import numpy as np
 from copy import deepcopy
 
-from pydmd import DMD
+from pydmd import DMD, CDMD, DMD, DMDBase, DMDc, FbDMD, HankelDMD, HODMD, MrDMD, OptDMD, ParametricDMD, SpDMD
 from pydmd.dmd_modes_tuner import select_modes, stabilize_modes, ModesSelectors, ModesTuner, selectors
+from ezyrb import POD, RBF
+import pytest
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -635,3 +637,17 @@ def test_modes_tuner_selectors():
     assert selectors['module_threshold'] == ModesSelectors.threshold
     assert selectors['stable_modes'] == ModesSelectors.stable_modes
     assert selectors['integral_contribution'] == ModesSelectors.integral_contribution
+
+@pytest.mark.parametrize("dmd", [CDMD(svd_rank=-1), DMD(svd_rank=-1), DMDc(svd_rank=-1), FbDMD(svd_rank=-1),
+    HankelDMD(svd_rank=-1, d=3), HODMD(svd_rank=-1, d=3), MrDMD(DMD(svd_rank=-1)), OptDMD(svd_rank=-1),
+    ParametricDMD(DMD(svd_rank=-1), POD(), None)])
+def test_modes_selector_all_dmd_types(dmd):
+    print('--------------------------- {} ---------------------------'.format(type(dmd)))
+    if isinstance(dmd, ParametricDMD):
+        repeated = np.repeat(sample_data[None], 10, axis=0)
+        dmd.fit(repeated + np.random.rand(*repeated.shape), np.ones(10))
+    else:
+        dmd.fit(sample_data)
+
+    ModesTuner(dmd, in_place=True).select('integral_contribution', n=3).stabilize(1-1.e-3)
+    assert True

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -59,7 +59,7 @@ class TestDmdBase(TestCase):
         # max/min throws an error if the array is empty (max used on empty
         # array)
         dmd.operator._eigenvalues = np.array([], dtype=complex)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             dmd.plot_eigs(show_axes=False, narrow_view=True, dpi=200)
 
     def test_plot_modes_2D(self):

--- a/tests/test_dmdc.py
+++ b/tests/test_dmdc.py
@@ -207,3 +207,13 @@ class TestDMDC(TestCase):
             dmd[[True, True, False, True]]
         with self.assertRaises(ValueError):
             dmd[1.0]
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        system = create_system_with_B()
+        dmd = DMDc(svd_rank=-1)
+        dmd.fit(system['snapshots'], system['u'], system['B'])
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_fbdmd.py
+++ b/tests/test_fbdmd.py
@@ -216,3 +216,12 @@ class TestFbDmd(TestCase):
             dmd[[True, True, False, True]]
         with self.assertRaises(ValueError):
             dmd[1.0]
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        dmd = FbDMD(svd_rank=-1)
+        dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_hankeldmd.py
+++ b/tests/test_hankeldmd.py
@@ -589,3 +589,12 @@ class TestHankelDmd(TestCase):
             dmd[[True, True, False, True]]
         with self.assertRaises(ValueError):
             dmd[1.0]
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        dmd = HankelDMD(svd_rank=-1, d=5)
+        dmd.fit(X=sample_data)
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._sub_dmd._b)

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -472,3 +472,12 @@ class TestHODmd(TestCase):
             dmd[[True, True, False, True]]
         with self.assertRaises(ValueError):
             dmd[1.0]
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        dmd = HODMD(svd_rank=-1, d=5)
+        dmd.fit(X=sample_data)
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._sub_dmd._b)

--- a/tests/test_paramdmd.py
+++ b/tests/test_paramdmd.py
@@ -389,9 +389,25 @@ def test_set_time_partitioned():
     dc['tend'] = 20
     dc['dt'] = 1
     p.dmd_time = dc
+    p._predict_modal_coefficients()
 
     for dmd in dmds:
         assert dmd.dmd_time == dc
         assert dmd.dmd_time['t0'] == 10
         assert dmd.dmd_time['dt'] == 1
         assert dmd.dmd_time['tend'] == 20
+
+def test_forecast():
+    dmds = [DMD(svd_rank=-1) for _ in range(len(params))]
+    p = ParametricDMD(dmds, POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
+
+    dc = DMDTimeDict()
+    dc['t0'] = 101
+    dc['tend'] = 200
+    dc['dt'] = 1
+    p.dmd_time = dc
+
+    for r in p.reconstructed_data:
+        assert r.shape == (100, training_data.shape[2])

--- a/tests/test_paramdmd.py
+++ b/tests/test_paramdmd.py
@@ -1,7 +1,9 @@
-from unittest import TestCase
+from pytest import raises
 from pydmd import DMD, ParametricDMD
+from pydmd.dmdbase import DMDTimeDict
 from ezyrb import POD, RBF
 import numpy as np
+import os
 
 testdir = 'tests/test_datasets/param_dmd/'
 
@@ -29,331 +31,367 @@ test_parameters = [0.15, 0.75, 0.28]
 # testing_data = np.vstack([f(a)(xgrid, tgrid)[None,:] for a in test_parameters])
 testing_data = np.load(testdir + 'testing_data.npy')
 
-class TestParamDmd(TestCase):
-    def test_is_partitioned_1(self):
-        assert not ParametricDMD(None, None, None).is_partitioned
+def test_is_partitioned_1():
+    assert not ParametricDMD(None, None, None).is_partitioned
 
-    def test_is_partitioned_2(self):
-        assert not ParametricDMD(DMD(), None, None).is_partitioned
+def test_is_partitioned_2():
+    assert not ParametricDMD(DMD(), None, None).is_partitioned
 
-    def test_is_partitioned_3(self):
-        assert ParametricDMD([DMD() for _ in range(3)], None, None).is_partitioned
+def test_is_partitioned_3():
+    assert ParametricDMD([DMD() for _ in range(3)], None, None).is_partitioned
 
-    def test_init(self):
-        d = DMD()
-        p = ParametricDMD(d, sum, np.mean)
-        assert p._dmd == d
-        assert p._spatial_pod == sum
-        assert p._approximation == np.mean
+def test_init():
+    d = DMD()
+    p = ParametricDMD(d, sum, np.mean)
+    assert p._dmd == d
+    assert p._spatial_pod == sum
+    assert p._approximation == np.mean
 
-    def test_reference_dmd_1(self):
-        d = DMD()
-        p = ParametricDMD(d, sum, np.mean)
-        assert p._reference_dmd == d
+def test_reference_dmd_1():
+    d = DMD()
+    p = ParametricDMD(d, sum, np.mean)
+    assert p._reference_dmd == d
 
-    def test_reference_dmd_2(self):
-        l = [DMD() for _ in range(3)]
-        p = ParametricDMD(l, sum, np.mean)
-        assert p._reference_dmd == l[0]
+def test_reference_dmd_2():
+    l = [DMD() for _ in range(3)]
+    p = ParametricDMD(l, sum, np.mean)
+    assert p._reference_dmd == l[0]
 
-    def test_dmd_time_1(self):
-        d = DMD()
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
-        d.dmd_time['t0'] = 100
+def test_dmd_time_1():
+    d = DMD()
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
+    d.dmd_time['t0'] = 100
 
-        p = ParametricDMD(d, sum, np.mean)
-        assert p.dmd_time['tend'] == 200
-        assert p.dmd_time['t0'] == 100
+    p = ParametricDMD(d, sum, np.mean)
+    assert p.dmd_time['tend'] == 200
+    assert p.dmd_time['t0'] == 100
 
-    def test_dmd_time_2(self):
-        l = [DMD() for _ in range(3)]
-        d = l[0]
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
-        d.dmd_time['t0'] = 100
+def test_dmd_time_2():
+    l = [DMD() for _ in range(3)]
+    d = l[0]
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
+    d.dmd_time['t0'] = 100
 
-        p = ParametricDMD(l, sum, np.mean)
-        assert p.dmd_time['tend'] == 200
-        assert p.dmd_time['t0'] == 100
+    p = ParametricDMD(l, sum, np.mean)
+    assert p.dmd_time['tend'] == 200
+    assert p.dmd_time['t0'] == 100
 
-    def test_dmd_timesteps_1(self):
-        d = DMD()
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
+def test_dmd_timesteps_1():
+    d = DMD()
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
 
-        p = ParametricDMD(d, sum, np.mean)
-        assert len(p.dmd_timesteps) == 201
-        assert p.dmd_timesteps[-1] == 200
+    p = ParametricDMD(d, sum, np.mean)
+    assert len(p.dmd_timesteps) == 201
+    assert p.dmd_timesteps[-1] == 200
 
-    def test_dmd_timesteps_2(self):
-        l = [DMD() for _ in range(3)]
-        d = l[0]
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
+def test_dmd_timesteps_2():
+    l = [DMD() for _ in range(3)]
+    d = l[0]
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
 
-        p = ParametricDMD(l, sum, np.mean)
-        assert len(p.dmd_timesteps) == 201
-        assert p.dmd_timesteps[-1] == 200
+    p = ParametricDMD(l, sum, np.mean)
+    assert len(p.dmd_timesteps) == 201
+    assert p.dmd_timesteps[-1] == 200
 
-    def test_original_time_1(self):
-        d = DMD()
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
+def test_original_time_1():
+    d = DMD()
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
 
-        p = ParametricDMD(d, sum, np.mean)
-        assert p.original_time['tend'] == 99
+    p = ParametricDMD(d, sum, np.mean)
+    assert p.original_time['tend'] == 99
 
-    def test_original_time_2(self):
-        l = [DMD() for _ in range(3)]
-        d = l[0]
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
+def test_original_time_2():
+    l = [DMD() for _ in range(3)]
+    d = l[0]
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
 
-        p = ParametricDMD(l, sum, np.mean)
-        assert p.original_time['tend'] == 99
+    p = ParametricDMD(l, sum, np.mean)
+    assert p.original_time['tend'] == 99
 
-    def test_original_timesteps_1(self):
-        d = DMD()
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
+def test_original_timesteps_1():
+    d = DMD()
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
 
-        p = ParametricDMD(d, sum, np.mean)
-        assert len(p.original_timesteps) == 100
-        assert p.original_timesteps[-1] == 99
+    p = ParametricDMD(d, sum, np.mean)
+    assert len(p.original_timesteps) == 100
+    assert p.original_timesteps[-1] == 99
 
-    def test_original_timesteps_2(self):
-        l = [DMD() for _ in range(3)]
-        d = l[0]
-        d.fit(np.ones((10,100)))
-        d.dmd_time['tend'] = 200
+def test_original_timesteps_2():
+    l = [DMD() for _ in range(3)]
+    d = l[0]
+    d.fit(np.ones((10,100)))
+    d.dmd_time['tend'] = 200
 
-        p = ParametricDMD(l, sum, np.mean)
-        assert len(p.original_timesteps) == 100
-        assert p.original_timesteps[-1] == 99
+    p = ParametricDMD(l, sum, np.mean)
+    assert len(p.original_timesteps) == 100
+    assert p.original_timesteps[-1] == 99
 
-    def test_training_parameters_1(self):
-        p = ParametricDMD(None, None, None)
-        p._set_training_parameters(np.ones(10))
-        assert p.training_parameters.shape == (10,1)
+def test_training_parameters_1():
+    p = ParametricDMD(None, None, None)
+    p._set_training_parameters(np.ones(10))
+    assert p.training_parameters.shape == (10,1)
 
-    def test_training_parameters_2(self):
-        p = ParametricDMD(None, None, None)
-        p._set_training_parameters([1 for _ in range(10)])
-        assert p.training_parameters.shape == (10,1)
+def test_training_parameters_2():
+    p = ParametricDMD(None, None, None)
+    p._set_training_parameters([1 for _ in range(10)])
+    assert p.training_parameters.shape == (10,1)
 
-    def test_training_parameters_3(self):
-        p = ParametricDMD(None, None, None)
-        with self.assertRaises(ValueError):
-            p._set_training_parameters(np.ones((10,2,2)))
+def test_training_parameters_3():
+    p = ParametricDMD(None, None, None)
+    with raises(ValueError):
+        p._set_training_parameters(np.ones((10,2,2)))
 
-    def test_parameters_1(self):
-        p = ParametricDMD(None, None, None)
-        p.parameters = np.ones(10)
-        assert p.parameters.shape == (10,1)
+def test_parameters_1():
+    p = ParametricDMD(None, None, None)
+    p.parameters = np.ones(10)
+    assert p.parameters.shape == (10,1)
 
-    def test_parameters_2(self):
-        p = ParametricDMD(None, None, None)
-        p.parameters = [1 for _ in range(10)]
-        assert p.parameters.shape == (10,1)
+def test_parameters_2():
+    p = ParametricDMD(None, None, None)
+    p.parameters = [1 for _ in range(10)]
+    assert p.parameters.shape == (10,1)
 
-    def test_parameters_3(self):
-        p = ParametricDMD(None, None, None)
-        with self.assertRaises(ValueError):
-            p.parameters = np.ones((10,2,2))
+def test_parameters_3():
+    p = ParametricDMD(None, None, None)
+    with raises(ValueError):
+        p.parameters = np.ones((10,2,2))
 
-    def test_fit_wrong_training_shape(self):
-        p = ParametricDMD(None, None, None)
-        with self.assertRaises(ValueError):
-            p.fit(np.ones((9,10,10)), [0 for _ in range(10)])
+def test_fit_wrong_training_shape():
+    p = ParametricDMD(None, None, None)
+    with raises(ValueError):
+        p.fit(np.ones((9,10,10)), [0 for _ in range(10)])
 
-    # assert that fit sets properly _ntrain, _time_instants, _space_dim
-    def test_fit_sets_quantities(self):
-        p = ParametricDMD(DMD(), POD(), None)
-        p.fit(np.ones((10,9,8)), [0 for _ in range(10)])
+# assert that fit sets properly _ntrain, _time_instants, _space_dim
+def test_fit_sets_quantities():
+    p = ParametricDMD(DMD(), POD(), None)
+    p.fit(np.ones((10,9,8)), [0 for _ in range(10)])
 
-        assert p._ntrain == 10
-        assert p._time_instants == 9
-        assert p._space_dim == 8
+    assert p._ntrain == 10
+    assert p._time_instants == 9
+    assert p._space_dim == 8
 
-    def test_fit_stores_training_parameters(self):
-        p = ParametricDMD(DMD(), POD(), None)
-        p.fit(np.ones((10,9,8)), [i for i in range(10)])
-        assert np.all(p.training_parameters == np.arange(10)[:,None])
+def test_fit_stores_training_parameters():
+    p = ParametricDMD(DMD(), POD(), None)
+    p.fit(np.ones((10,9,8)), [i for i in range(10)])
+    assert np.all(p.training_parameters == np.arange(10)[:,None])
 
-    def test_fit_stores_2d_training_parameters(self):
-        params = np.hstack([
-            np.arange(10)[:,None],
-            np.flip(np.arange(10))[:,None]
-        ])
+def test_fit_stores_2d_training_parameters():
+    params = np.hstack([
+        np.arange(10)[:,None],
+        np.flip(np.arange(10))[:,None]
+    ])
 
-        p = ParametricDMD(DMD(), POD(), None)
-        p.fit(np.ones((10,9,8)), params)
+    p = ParametricDMD(DMD(), POD(), None)
+    p.fit(np.ones((10,9,8)), params)
 
-        # test shape
-        assert p.training_parameters.shape == (10,2)
-        # test that the order is fine
-        assert np.all(np.sum(p.training_parameters, axis=1) == np.repeat(9, 10))
+    # test shape
+    assert p.training_parameters.shape == (10,2)
+    # test that the order is fine
+    assert np.all(np.sum(p.training_parameters, axis=1) == np.repeat(9, 10))
 
-    def test_training_modal_coefficients_shape(self):
-        p = ParametricDMD(None, POD(rank=5), None)
-        p._ntrain = 10
+def test_training_modal_coefficients_shape():
+    p = ParametricDMD(None, POD(rank=5), None)
+    p._ntrain = 10
 
-        res = p._training_modal_coefficients(np.ones((50,60)))
-        assert len(res) == 10
-        assert res[0].shape == (5,6)
+    res = p._training_modal_coefficients(np.ones((50,60)))
+    assert len(res) == 10
+    assert res[0].shape == (5,6)
 
-    def test_training_modal_coefficients(self):
-        m = np.vander(np.arange(50)/50, 60)
-        p = ParametricDMD(None, POD(rank=5), None)
-        p._ntrain = 10
-        np.testing.assert_allclose(np.hstack(p._training_modal_coefficients(m)), POD(rank=5).fit(m).reduce(m))
+def test_training_modal_coefficients():
+    m = np.vander(np.arange(50)/50, 60)
+    p = ParametricDMD(None, POD(rank=5), None)
+    p._ntrain = 10
+    np.testing.assert_allclose(np.hstack(p._training_modal_coefficients(m)), POD(rank=5).fit(m).reduce(m))
 
-    def test_training_modal_coefficients2(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
+def test_training_modal_coefficients2():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
 
-        inp = np.load(testdir+'space_timemu.npy')
-        actual = p._training_modal_coefficients(inp)
-        expected = np.load(testdir+'traning_modal_coefficients.npy')
+    inp = np.load(testdir+'space_timemu.npy')
+    actual = p._training_modal_coefficients(inp)
+    expected = np.load(testdir+'traning_modal_coefficients.npy')
 
-        np.testing.assert_allclose(actual, expected, atol=1.e-12, rtol=0)
+    np.testing.assert_allclose(actual, expected, atol=1.e-12, rtol=0)
 
-    def test_arrange_parametric_snapshots_shape(self):
-        p = ParametricDMD(None, None, None)
-        p._space_dim = 30
-        p._time_instants = 20
-        p._ntrain = 10
-        assert p._arrange_parametric_snapshots(np.ones((10,20,30))).shape == (30, 200)
+def test_arrange_parametric_snapshots_shape():
+    p = ParametricDMD(None, None, None)
+    p._space_dim = 30
+    p._time_instants = 20
+    p._ntrain = 10
+    assert p._arrange_parametric_snapshots(np.ones((10,20,30))).shape == (30, 200)
 
-    def test_arrange_parametric_snapshots(self):
-        p = ParametricDMD(None, None, None)
-        p._space_dim = 3
-        p._time_instants = 2
-        p._ntrain = 2
+def test_arrange_parametric_snapshots():
+    p = ParametricDMD(None, None, None)
+    p._space_dim = 3
+    p._time_instants = 2
+    p._ntrain = 2
 
-        m1 = np.array([
-            [1,2,3],
-            [4,5,6]
-        ])[None,:]
-        m2 = np.array([
-            [0,1,0,],
-            [1,1,0]
-        ])[None,:]
-        m = np.vstack([m1,m2])
+    m1 = np.array([
+        [1,2,3],
+        [4,5,6]
+    ])[None,:]
+    m2 = np.array([
+        [0,1,0,],
+        [1,1,0]
+    ])[None,:]
+    m = np.vstack([m1,m2])
 
-        expected = np.array([
-            [1,4,0,1],
-            [2,5,1,1],
-            [3,6,0,0],
-        ])
+    expected = np.array([
+        [1,4,0,1],
+        [2,5,1,1],
+        [3,6,0,0],
+    ])
 
-        np.testing.assert_array_equal(expected, p._arrange_parametric_snapshots(m))
+    np.testing.assert_array_equal(expected, p._arrange_parametric_snapshots(m))
 
-    def test_arrange_parametric_snapshots2(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
+def test_arrange_parametric_snapshots2():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
 
-        expected = np.load(testdir+'space_timemu.npy')
-        actual = p._arrange_parametric_snapshots(training_data)
-        np.testing.assert_allclose(actual, expected)
+    expected = np.load(testdir+'space_timemu.npy')
+    actual = p._arrange_parametric_snapshots(training_data)
+    np.testing.assert_allclose(actual, expected)
 
-    def test_fit_dmd_partitioned(self):
-        p = ParametricDMD([DMD() for _ in range(5)], None, None)
-        p._fit_dmd([np.ones((20,10)) for _ in range(5)])
-        for i in range(5):
-            # assert that fit was called
-            assert p._dmd[i].modes is not None
-            assert p._dmd[i].modes.shape[0] == 20
-
-    def test_fit_dmd_monolithic(self):
-        p = ParametricDMD(DMD(), None, None)
-        p._fit_dmd([np.ones((20,10)) for _ in range(5)])
+def test_fit_dmd_partitioned():
+    p = ParametricDMD([DMD() for _ in range(5)], None, None)
+    p._fit_dmd([np.ones((20,10)) for _ in range(5)])
+    for i in range(5):
         # assert that fit was called
-        assert p._dmd.modes is not None
-        assert p._dmd.modes.shape[0] == 100
+        assert p._dmd[i].modes is not None
+        assert p._dmd[i].modes.shape[0] == 20
 
-    def test_predict_modal_coefficients_shape(self):
-        p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
-        p.fit(np.ones((10,20,40)), np.arange(10))
-        p.dmd_time['tend'] = 29
-        assert p._predict_modal_coefficients().shape == (10*10, 30)
+def test_fit_dmd_monolithic():
+    p = ParametricDMD(DMD(), None, None)
+    p._fit_dmd([np.ones((20,10)) for _ in range(5)])
+    # assert that fit was called
+    assert p._dmd.modes is not None
+    assert p._dmd.modes.shape[0] == 100
 
-    def test_predict_modal_coefficients_partitioned_shape(self):
-        p = ParametricDMD([DMD(svd_rank=5) for _ in range(10)], POD(rank=10), RBF())
-        p.fit(np.ones((10,20,40)), np.arange(10))
-        p.dmd_time['tend'] = 29
-        assert p._predict_modal_coefficients().shape == (10*10, 30)
+def test_predict_modal_coefficients_shape():
+    p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
+    p.fit(np.ones((10,20,40)), np.arange(10))
+    p.dmd_time['tend'] = 29
+    assert p._predict_modal_coefficients().shape == (10*10, 30)
 
-    def test_predict_modal_coefficients(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
+def test_predict_modal_coefficients_partitioned_shape():
+    p = ParametricDMD([DMD(svd_rank=5) for _ in range(10)], POD(rank=10), RBF())
+    p.fit(np.ones((10,20,40)), np.arange(10))
+    p.dmd_time['tend'] = 29
+    assert p._predict_modal_coefficients().shape == (10*10, 30)
 
-        expected = np.load(testdir+'forecasted.npy')
-        np.testing.assert_allclose(p._predict_modal_coefficients(), expected, rtol=0, atol=1.e-11)
+def test_predict_modal_coefficients():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
 
-    def test_interpolate_missing_modal_coefficients_shape(self):
-        p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
-        p.fit(np.ones((10,20,40)), np.arange(10))
-        p.dmd_time['tend'] = 29
-        p.parameters = [1.5, 5.5, 7.5]
-        assert p._interpolate_missing_modal_coefficients(np.random.rand(10*10, 30)).shape == (30,3,10)
+    expected = np.load(testdir+'forecasted.npy')
+    np.testing.assert_allclose(p._predict_modal_coefficients(), expected, rtol=0, atol=1.e-11)
 
-    def test_interpolate_missing_modal_coefficients_wrong_time(self):
-        p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
-        p.fit(np.ones((10,20,40)), np.arange(10))
-        p.dmd_time['tend'] = 29
-        p.parameters = [1.5, 5.5, 7.5]
-        with self.assertRaises(ValueError):
-            p._interpolate_missing_modal_coefficients(np.random.rand(10*10, 20))
+def test_interpolate_missing_modal_coefficients_shape():
+    p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
+    p.fit(np.ones((10,20,40)), np.arange(10))
+    p.dmd_time['tend'] = 29
+    p.parameters = [1.5, 5.5, 7.5]
+    assert p._interpolate_missing_modal_coefficients(np.random.rand(10*10, 30)).shape == (30,3,10)
 
-    def test_interpolate_missing_modal_coefficients(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
-        p.parameters = test_parameters
+def test_interpolate_missing_modal_coefficients_wrong_time():
+    p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
+    p.fit(np.ones((10,20,40)), np.arange(10))
+    p.dmd_time['tend'] = 29
+    p.parameters = [1.5, 5.5, 7.5]
+    with raises(ValueError):
+        p._interpolate_missing_modal_coefficients(np.random.rand(10*10, 20))
 
-        expected = np.load(testdir+'interpolated.npy')
-        np.testing.assert_allclose(
-            p._interpolate_missing_modal_coefficients(np.load(testdir+'forecasted.npy')),
-            expected, atol=1.e-12, rtol=0)
+def test_interpolate_missing_modal_coefficients():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
 
-    def reconstructed_data_shape(self):
-        p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
-        p.fit(np.random.rand(10,20,50), np.arange(10))
-        p.dmd_time['tend'] = 39
-        p.parameters = [1.5, 5.5, 7.5,8.5]
-        assert p.reconstructed_data.shape == (4, 40, 50)
+    expected = np.load(testdir+'interpolated.npy')
+    np.testing.assert_allclose(
+        p._interpolate_missing_modal_coefficients(np.load(testdir+'forecasted.npy')),
+        expected, atol=1.e-12, rtol=0)
 
-    def test_reconstructed_data_noprediction(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
-        p.parameters = test_parameters
+def reconstructed_data_shape():
+    p = ParametricDMD(DMD(svd_rank=5), POD(rank=10), RBF())
+    p.fit(np.random.rand(10,20,50), np.arange(10))
+    p.dmd_time['tend'] = 39
+    p.parameters = [1.5, 5.5, 7.5,8.5]
+    assert p.reconstructed_data.shape == (4, 40, 50)
 
-        rec = p.reconstructed_data
+def test_reconstructed_data_noprediction():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
 
-        assert rec.shape == (3,100,1000)
+    rec = p.reconstructed_data
 
-        np.testing.assert_allclose(rec.real, testing_data.real, atol=1.e-2)
+    assert rec.shape == (3,100,1000)
 
-    def test_save(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
-        p.parameters = test_parameters
-        p.save('pydmd.test')
+    np.testing.assert_allclose(rec.real, testing_data.real, atol=1.e-2)
 
-    def test_load(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
-        p.parameters = test_parameters
-        p.save('pydmd.test2')
-        loaded_p = ParametricDMD.load('pydmd.test2')
-        np.testing.assert_array_equal(p.reconstructed_data,
-                                      loaded_p.reconstructed_data)
+def test_save():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
+    p.save('pydmd.test')
+    os.remove('pydmd.test')
 
-    def test_load(self):
-        p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
-        p.fit(training_data, params)
-        p.parameters = test_parameters
-        p.save('pydmd.test2')
-        loaded_p = ParametricDMD.load('pydmd.test2')
-        assert isinstance(loaded_p, ParametricDMD)
+def test_load():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
+    p.save('pydmd.test2')
+    loaded_p = ParametricDMD.load('pydmd.test2')
+    np.testing.assert_array_equal(p.reconstructed_data,
+                                    loaded_p.reconstructed_data)
+    os.remove('pydmd.test2')
+
+def test_load():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
+    p.save('pydmd.test2')
+    loaded_p = ParametricDMD.load('pydmd.test2')
+    assert isinstance(loaded_p, ParametricDMD)
+    os.remove('pydmd.test2')
+
+def test_set_time_monolithic():
+    p = ParametricDMD(DMD(svd_rank=-1), POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
+
+    dc = DMDTimeDict()
+    dc['t0'] = 10
+    dc['tend'] = 20
+    dc['dt'] = 1
+    p.dmd_time = dc
+
+    assert p.dmd_time == dc
+    assert p.dmd_time['t0'] == 10
+    assert p.dmd_time['dt'] == 1
+    assert p.dmd_time['tend'] == 20
+
+def test_set_time_partitioned():
+    dmds = [DMD(svd_rank=-1) for _ in range(len(params))]
+    p = ParametricDMD(dmds, POD(rank=5), RBF())
+    p.fit(training_data, params)
+    p.parameters = test_parameters
+
+    dc = DMDTimeDict()
+    dc['t0'] = 10
+    dc['tend'] = 20
+    dc['dt'] = 1
+    p.dmd_time = dc
+
+    for dmd in dmds:
+        assert dmd.dmd_time == dc
+        assert dmd.dmd_time['t0'] == 10
+        assert dmd.dmd_time['dt'] == 1
+        assert dmd.dmd_time['tend'] == 20

--- a/tests/test_spdmd.py
+++ b/tests/test_spdmd.py
@@ -285,3 +285,12 @@ class TestSpDmd(TestCase):
             dmd[[True, True, False, True]]
         with self.assertRaises(ValueError):
             dmd[1.0]
+
+    # this is a test for the correctness of the amplitudes saved in the Proxy
+    # between DMDBase and the modes activation bitmask. if this test fails
+    # you probably need to call allocate_proxy once again after you compute
+    # the final value of the amplitudes
+    def test_correct_amplitudes(self):
+        dmd = SpDMD(release_memory=True, svd_rank=-1)
+        dmd.fit(X=data)
+        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)


### PR DESCRIPTION
Changelog:
- Introduced the parameter `nullify_amplitudes` (defaults to `False`) which allows setting to zero the amplitudes corresponding to DMD modes to be cut in `select_modes()` or `ModesTuner.select()`;
- Improved test coverage (some lines were uncovered since my last PR);
- `ModesTuner.select()/stabilize()` now return `self` (i.e. the calling instance of `ModesTuner`) in order to allow chaining multiple operations with less code.

For instance, this is now valid:
```python
new_dmd1, new_dmd2 = (
        ModesTuner([dmd1, dmd2])
        .select("integral_contribution", n=5)
        .select(
            "module_threshold",
            low_threshold=1 - 1.0e-5,
            up_threshold=1 + 1.0e-2,
        )
        .stabilize(inner_radius=1 - 1.0e-3)
        .get()
    )
```