### PR TITLE
Fix reference to `_optimal_dmd_matrixes`

### DIFF
--- a/pydmd/dmdbase.py
+++ b/pydmd/dmdbase.py
@@ -766,7 +766,7 @@ matrix, or regularization methods.""".format(
         """
         if isinstance(self.opt, bool) and self.opt:
             # b optimal
-            a = np.linalg.solve(*self._optimal_dmd_matrixes())
+            a = np.linalg.solve(*self._optimal_dmd_matrices())
         else:
             if isinstance(self.opt, bool):
                 amplitudes_snapshot_index = 0


### PR DESCRIPTION
After e99853871f59639a5f2e0195d2038c674f85576d there was a last reference to `_optimal_dmd_matrixes` which caused a widespread failure in tests.