### PR TITLE
Provide default config for `pytest`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --tb=short
+filterwarnings =
+    ignore:.*:DeprecationWarning
+    ignore:.*:UserWarning


### PR DESCRIPTION
In this PR I added a configuration file for `pytest`.

```yaml
filterwarnings =
    ignore:.*:DeprecationWarning
    ignore:.*:UserWarning
```
These lines force `pyest` to ignore warnings about conditioning number (which usually clutter the output since most tests use toy data) and Matplotlib warnings.

```yaml
addopts = --tb=short
```
This reduces the number of lines which `pytest` allocates for the code which caused a failure. By default (at least on my computer) it used to show many unrelated lines, and even the docstring related to the function which threw the exception, which meant that looking at the whole output took a lot of scrolling.