### PR TITLE
[MrDMD] Enable per-level (and per-leaf) choice of DMD implementation

### DIFF
--- a/docs/source/mrdmd.rst
+++ b/docs/source/mrdmd.rst
@@ -25,6 +25,7 @@ MrDMD
 	MrDMD.plot_snapshots_2D
 	MrDMD.reconstructed_data
 	MrDMD.snapshots
+	MrDMD._dmd_builder
 
 
 .. autoclass:: MrDMD

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -67,11 +67,12 @@ class MrDMD(DMDBase):
         recursively analyze the dataset.
     :param int max_cycles: the maximum number of mode oscillations in any given
         time scale. Default is 1.
-    :param int max_level: the maximum number of levels. Defualt is 6.
+    :param int max_level: the maximum level (inclusive). For instance,
+        `max_level=4` means that we are going to have levels `0`, `1`, `2`, `3`
+        and `4`. Default is 2.
     """
 
     def __init__(self, dmd, max_level=2, max_cycles=1):
-
         self.dmd = dmd
         self.max_cycles = max_cycles
         self.max_level = max_level


### PR DESCRIPTION
There are some use cases (see #251) in which it would be convenient to select different kinds of DMDs according to the level inside `MrDMD`, or to change some parameter depending on the depth. 

In this PR I added the method `_dmd_builder`, which provides DMD-builder functions and generalizes the current approach for the construction of DMD instances. After this PR the parameter `dmd` of the constructor of `MrDMD` accepts values of type `list`, `tuple`, `function` and `DMDBase`. See the documentation of ´MrDMD._dmd_builder´ for more details and examples.

### Example
We use a different kind of DMD if we are near the middle part of the time window:
```python
>>> def my_dmds(level, leaf):
...     level_size = pow(2,level)
...     distance_from_middle = abs(leaf - level_size // 2)
...     # we choose 2 as a random threshold
...     if distance_from_middle < 2:
...         return HankelDMD(d=5)
...     else:
...         return DMD(svd_rank=3)
>>> MrDMD(dmd=my_dmds, max_level=5).fit(X)
```