### PR TITLE
Improve error message from [Hankel/HO]DMD

### DIFF
--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -330,12 +330,22 @@ class HankelDMD(DMDBase):
         :param X: the input snapshots.
         :type X: numpy.ndarray or iterable
         """
+
+        if isinstance(X, np.ndarray) and X.ndim == 2:
+            n_samples = X.shape[1]
+        else:
+            n_samples = len(X)
+
+        if n_samples < self._d:
+            msg = """The number of snapshots provided is not enough for d={}.
+Expected at least d."""
+            raise ValueError(msg.format(self._d))
+
         snp, self._snapshots_shape = self._col_major_2darray(X)
         self._snapshots = self._pseudo_hankel_matrix(snp)
         self._sub_dmd.fit(self._snapshots)
 
         # Default timesteps
-        n_samples = snp.shape[1]
         self._set_initial_time_dictionary(
             {"t0": 0, "tend": n_samples - 1, "dt": 1}
         )

--- a/tests/test_hankeldmd.py
+++ b/tests/test_hankeldmd.py
@@ -1,5 +1,5 @@
 from builtins import range
-from unittest import TestCase
+from pytest import raises
 from pydmd import HankelDMD
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,571 +32,576 @@ def create_noisy_data():
 noisy_data = create_noisy_data()
 
 
-class TestHankelDmd(TestCase):
-    def test_shape(self):
-        dmd = HankelDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == sample_data.shape[1] - 1
+def test_shape():
+    dmd = HankelDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == sample_data.shape[1] - 1
 
-    def test_truncation_shape(self):
-        dmd = HankelDMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == 3
+def test_truncation_shape():
+    dmd = HankelDMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == 3
 
-    def test_rank(self):
-        dmd = HankelDMD(svd_rank=0.9)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 2
+def test_rank():
+    dmd = HankelDMD(svd_rank=0.9)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 2
 
-    def test_Atilde_shape(self):
-        dmd = HankelDMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
+def test_Atilde_shape():
+    dmd = HankelDMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
 
-    def test_d(self):
-        single_data = np.sin(np.linspace(0, 10, 100))
-        dmd = HankelDMD(svd_rank=0, d=50, opt=True)
-        dmd.fit(single_data)
-        np.testing.assert_array_almost_equal(
-            dmd.reconstructed_data.flatten().real,
-            single_data,
-            decimal=1) # TODO poor accuracy using projected modes
-        dmd = HankelDMD(svd_rank=-1, d=50, opt=True, exact=True)
-        dmd.fit(single_data)
-        assert np.allclose(dmd.reconstructed_data.flatten().real, single_data)
+def test_d():
+    single_data = np.sin(np.linspace(0, 10, 100))
+    dmd = HankelDMD(svd_rank=0, d=50, opt=True)
+    dmd.fit(single_data)
+    np.testing.assert_array_almost_equal(
+        dmd.reconstructed_data.flatten().real,
+        single_data,
+        decimal=1) # TODO poor accuracy using projected modes
+    dmd = HankelDMD(svd_rank=-1, d=50, opt=True, exact=True)
+    dmd.fit(single_data)
+    assert np.allclose(dmd.reconstructed_data.flatten().real, single_data)
 
-    def test_Atilde_values(self):
-        dmd = HankelDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        exact_atilde = np.array(
-            [
-                [-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
-                [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j],
-            ]
-        )
-        np.testing.assert_allclose(exact_atilde, dmd.atilde)
-
-    def test_eigs_1(self):
-        dmd = HankelDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 14
-
-    def test_eigs_2(self):
-        dmd = HankelDMD(svd_rank=5)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 5
-
-    def test_eigs_3(self):
-        dmd = HankelDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_eigs = np.array(
-            [
-                -8.09016994e-01 + 5.87785252e-01j,
-                -4.73868662e-01 + 8.80595532e-01j,
-            ]
-        )
-        np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
-
-    def test_dynamics_1(self):
-        dmd = HankelDMD(svd_rank=5)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
-
-    def test_dynamics_2(self):
-        dmd = HankelDMD(svd_rank=1)
-        dmd.fit(X=sample_data)
-        expected_dynamics = np.array(
-            [
-                [
-                    -2.20639502 - 9.10168802e-16j,
-                    1.55679980 - 1.49626864e00j,
-                    -0.08375915 + 2.11149018e00j,
-                    -1.37280962 - 1.54663768e00j,
-                    2.01748787 + 1.60312745e-01j,
-                    -1.53222592 + 1.25504678e00j,
-                    0.23000498 - 1.92462280e00j,
-                    1.14289644 + 1.51396355e00j,
-                    -1.83310653 - 2.93174173e-01j,
-                    1.49222925 - 1.03626336e00j,
-                    -0.35015209 + 1.74312867e00j,
-                    -0.93504202 - 1.46738182e00j,
-                    1.65485808 + 4.01263449e-01j,
-                    -1.43976061 + 8.39117825e-01j,
-                    0.44682540 - 1.56844403e00j,
-                ]
-            ]
-        )
-        np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
-
-    def test_dynamics_opt_1(self):
-        dmd = HankelDMD(svd_rank=5, opt=True)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
-
-    def test_dynamics_opt_2(self):
-        dmd = HankelDMD(svd_rank=1, opt=True, exact=False)
-        dmd.fit(X=sample_data)
-        expected_dynamics = np.array([[
-            -4.609718826226513-6.344781724790875j,
-            7.5552686987577165+1.3506997434096375j,
-            -6.246864367654589+4.170577993207872j,
-            1.5794144248628537-7.179014663490048j,
-            3.754043295828462+6.13648812118528j,
-            -6.810262177959786-1.7840079278093528j,
-            6.015047060133346-3.35961532862783j,
-            -1.9658025630719695+6.449604262000736j,
-            -2.9867632454837936-5.8838563367460734j,
-            6.097558230017521+2.126086276430128j,
-            -5.7441543819530265+2.6349291080417103j,
-            2.266111252852836-5.7545702519088895j,
-            2.303531963541068+5.597105176945707j,
-            -5.421019770795679-2.3870927539102658j,
-            5.443800581850978-1.9919716610066682j,
-        ]])
-        np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
-
-    def test_reconstructed_data(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        dmd_data = dmd.reconstructed_data
-        np.testing.assert_allclose(dmd_data, sample_data)
-
-    def test_original_time(self):
-        dmd = HankelDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {"dt": 1, "t0": 0, "tend": 14}
-        np.testing.assert_equal(dmd.original_time, expected_dict)
-
-    def test_original_timesteps(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        np.testing.assert_allclose(
-            dmd.original_timesteps, np.arange(sample_data.shape[1])
-        )
-
-    def test_dmd_time_1(self):
-        dmd = HankelDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {"dt": 1, "t0": 0, "tend": 14}
-        np.testing.assert_equal(dmd.dmd_time, expected_dict)
-
-    def test_dmd_time_2(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time["t0"] = 10
-        dmd.dmd_time["tend"] = 14
-        expected_data = sample_data[:, -5:]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
-
-    def test_dmd_time_3(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time["t0"] = 8
-        dmd.dmd_time["tend"] = 11
-        expected_data = sample_data[:, 8:12]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
-
-    def test_dmd_time_4(self):
-        dmd = HankelDMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.dmd_time["t0"] = 20
-        dmd.dmd_time["tend"] = 20
-        expected_data = np.array(
-            [
-                [-7.29383297e00 - 4.90248179e-14j],
-                [-5.69109796e00 - 2.74068833e00j],
-                [3.38410649e-83 + 3.75677740e-83j],
-            ]
-        )
-        np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
-
-    def test_dmd_time_5(self):
-        x = np.linspace(0, 10, 64)
-        y = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
-
-        dmd = HankelDMD(svd_rank=-1, exact=True, opt=True, d=30)
-        dmd.fit(y)
-
-        dmd.original_time["dt"] = dmd.dmd_time["dt"] = x[1] - x[0]
-        dmd.original_time["t0"] = dmd.dmd_time["t0"] = x[0]
-        dmd.original_time["tend"] = dmd.dmd_time["tend"] = x[-1]
-
-        assert dmd.reconstructed_data.shape == (1, 64)
-
-    def test_plot_eigs_1(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=True, show_unit_circle=True)
-        plt.close()
-
-    def test_plot_eigs_2(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
-
-    def test_plot_modes_1(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_modes_2D()
-
-    def test_plot_modes_2(self):
-        dmd = HankelDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
-
-    def test_plot_modes_3(self):
-        dmd = HankelDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D()
-        plt.close()
-
-    def test_plot_modes_4(self):
-        dmd = HankelDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1)
-        plt.close()
-
-    def test_plot_modes_5(self):
-        dmd = HankelDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1, filename="tmp.png")
-        self.addCleanup(os.remove, "tmp.1.png")
-
-    def test_plot_snapshots_1(self):
-        dmd = HankelDMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_snapshots_2D()
-
-    def test_plot_snapshots_2(self):
-        dmd = HankelDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
-
-    def test_plot_snapshots_3(self):
-        dmd = HankelDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D()
-        plt.close()
-
-    def test_plot_snapshots_4(self):
-        dmd = HankelDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2)
-        plt.close()
-
-    def test_plot_snapshots_5(self):
-        dmd = HankelDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2, filename="tmp.png")
-        self.addCleanup(os.remove, "tmp.2.png")
-
-    def test_tdmd_plot(self):
-        dmd = HankelDMD(tlsq_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
-
-    def test_sorted_eigs_default(self):
-        dmd = HankelDMD()
-        assert dmd.operator._sorted_eigs == False
-
-    def test_sorted_eigs_param(self):
-        dmd = HankelDMD(sorted_eigs="real")
-        assert dmd.operator._sorted_eigs == "real"
-
-    def test_reconstruction_method_constructor_error(self):
-        with self.assertRaises(ValueError):
-            HankelDMD(reconstruction_method=[1, 2, 3], d=4)
-
-        with self.assertRaises(ValueError):
-            HankelDMD(reconstruction_method=np.array([1, 2, 3]), d=4)
-
-        with self.assertRaises(ValueError):
-            HankelDMD(
-                reconstruction_method=np.array([[1, 2, 3], [3, 4, 5]]), d=3
-            )
-
-    def test_reconstruction_method_default_constructor(self):
-        assert HankelDMD()._reconstruction_method == "first"
-
-    def test_reconstruction_method_constructor(self):
-        assert (
-            HankelDMD(reconstruction_method="mean")._reconstruction_method
-            == "mean"
-        )
-        assert HankelDMD(reconstruction_method=[3])._reconstruction_method == [
-            3
+def test_Atilde_values():
+    dmd = HankelDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    exact_atilde = np.array(
+        [
+            [-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
+            [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j],
         ]
-        assert all(
-            HankelDMD(
-                reconstruction_method=np.array([1, 2]), d=2
-            )._reconstruction_method
-            == np.array([1, 2])
+    )
+    np.testing.assert_allclose(exact_atilde, dmd.atilde)
+
+def test_eigs_1():
+    dmd = HankelDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 14
+
+def test_eigs_2():
+    dmd = HankelDMD(svd_rank=5)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 5
+
+def test_eigs_3():
+    dmd = HankelDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_eigs = np.array(
+        [
+            -8.09016994e-01 + 5.87785252e-01j,
+            -4.73868662e-01 + 8.80595532e-01j,
+        ]
+    )
+    np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
+
+def test_dynamics_1():
+    dmd = HankelDMD(svd_rank=5)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
+
+def test_dynamics_2():
+    dmd = HankelDMD(svd_rank=1)
+    dmd.fit(X=sample_data)
+    expected_dynamics = np.array(
+        [
+            [
+                -2.20639502 - 9.10168802e-16j,
+                1.55679980 - 1.49626864e00j,
+                -0.08375915 + 2.11149018e00j,
+                -1.37280962 - 1.54663768e00j,
+                2.01748787 + 1.60312745e-01j,
+                -1.53222592 + 1.25504678e00j,
+                0.23000498 - 1.92462280e00j,
+                1.14289644 + 1.51396355e00j,
+                -1.83310653 - 2.93174173e-01j,
+                1.49222925 - 1.03626336e00j,
+                -0.35015209 + 1.74312867e00j,
+                -0.93504202 - 1.46738182e00j,
+                1.65485808 + 4.01263449e-01j,
+                -1.43976061 + 8.39117825e-01j,
+                0.44682540 - 1.56844403e00j,
+            ]
+        ]
+    )
+    np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
+
+def test_dynamics_opt_1():
+    dmd = HankelDMD(svd_rank=5, opt=True)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
+
+def test_dynamics_opt_2():
+    dmd = HankelDMD(svd_rank=1, opt=True, exact=False)
+    dmd.fit(X=sample_data)
+    expected_dynamics = np.array([[
+        -4.609718826226513-6.344781724790875j,
+        7.5552686987577165+1.3506997434096375j,
+        -6.246864367654589+4.170577993207872j,
+        1.5794144248628537-7.179014663490048j,
+        3.754043295828462+6.13648812118528j,
+        -6.810262177959786-1.7840079278093528j,
+        6.015047060133346-3.35961532862783j,
+        -1.9658025630719695+6.449604262000736j,
+        -2.9867632454837936-5.8838563367460734j,
+        6.097558230017521+2.126086276430128j,
+        -5.7441543819530265+2.6349291080417103j,
+        2.266111252852836-5.7545702519088895j,
+        2.303531963541068+5.597105176945707j,
+        -5.421019770795679-2.3870927539102658j,
+        5.443800581850978-1.9919716610066682j,
+    ]])
+    np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
+
+def test_reconstructed_data():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    dmd_data = dmd.reconstructed_data
+    np.testing.assert_allclose(dmd_data, sample_data)
+
+def test_original_time():
+    dmd = HankelDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {"dt": 1, "t0": 0, "tend": 14}
+    np.testing.assert_equal(dmd.original_time, expected_dict)
+
+def test_original_timesteps():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    np.testing.assert_allclose(
+        dmd.original_timesteps, np.arange(sample_data.shape[1])
+    )
+
+def test_dmd_time_1():
+    dmd = HankelDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {"dt": 1, "t0": 0, "tend": 14}
+    np.testing.assert_equal(dmd.dmd_time, expected_dict)
+
+def test_dmd_time_2():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time["t0"] = 10
+    dmd.dmd_time["tend"] = 14
+    expected_data = sample_data[:, -5:]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+
+def test_dmd_time_3():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time["t0"] = 8
+    dmd.dmd_time["tend"] = 11
+    expected_data = sample_data[:, 8:12]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+
+def test_dmd_time_4():
+    dmd = HankelDMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.dmd_time["t0"] = 20
+    dmd.dmd_time["tend"] = 20
+    expected_data = np.array(
+        [
+            [-7.29383297e00 - 4.90248179e-14j],
+            [-5.69109796e00 - 2.74068833e00j],
+            [3.38410649e-83 + 3.75677740e-83j],
+        ]
+    )
+    np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
+
+def test_dmd_time_5():
+    x = np.linspace(0, 10, 64)
+    y = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+
+    dmd = HankelDMD(svd_rank=-1, exact=True, opt=True, d=30)
+    dmd.fit(y)
+
+    dmd.original_time["dt"] = dmd.dmd_time["dt"] = x[1] - x[0]
+    dmd.original_time["t0"] = dmd.dmd_time["t0"] = x[0]
+    dmd.original_time["tend"] = dmd.dmd_time["tend"] = x[-1]
+
+    assert dmd.reconstructed_data.shape == (1, 64)
+
+def test_plot_eigs_1():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=True, show_unit_circle=True)
+    plt.close()
+
+def test_plot_eigs_2():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
+
+def test_plot_modes_1():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
+        dmd.plot_modes_2D()
+
+def test_plot_modes_2():
+    dmd = HankelDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
+
+def test_plot_modes_3():
+    dmd = HankelDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D()
+    plt.close()
+
+def test_plot_modes_4():
+    dmd = HankelDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1)
+    plt.close()
+
+def test_plot_modes_5():
+    dmd = HankelDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1, filename="tmp.png")
+    os.remove("tmp.1.png")
+
+def test_plot_snapshots_1():
+    dmd = HankelDMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
+        dmd.plot_snapshots_2D()
+
+def test_plot_snapshots_2():
+    dmd = HankelDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
+
+def test_plot_snapshots_3():
+    dmd = HankelDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D()
+    plt.close()
+
+def test_plot_snapshots_4():
+    dmd = HankelDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2)
+    plt.close()
+
+def test_plot_snapshots_5():
+    dmd = HankelDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2, filename="tmp.png")
+    os.remove("tmp.2.png")
+
+def test_tdmd_plot():
+    dmd = HankelDMD(tlsq_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
+
+def test_sorted_eigs_default():
+    dmd = HankelDMD()
+    assert dmd.operator._sorted_eigs == False
+
+def test_sorted_eigs_param():
+    dmd = HankelDMD(sorted_eigs="real")
+    assert dmd.operator._sorted_eigs == "real"
+
+def test_reconstruction_method_constructor_error():
+    with raises(ValueError):
+        HankelDMD(reconstruction_method=[1, 2, 3], d=4)
+
+    with raises(ValueError):
+        HankelDMD(reconstruction_method=np.array([1, 2, 3]), d=4)
+
+    with raises(ValueError):
+        HankelDMD(
+            reconstruction_method=np.array([[1, 2, 3], [3, 4, 5]]), d=3
         )
 
-    def test_nonan_nomask(self):
-        dmd = HankelDMD(d=3)
-        dmd.fit(X=sample_data)
-        rec = dmd.reconstructed_data
+def test_reconstruction_method_default_constructor():
+    assert HankelDMD()._reconstruction_method == "first"
 
-        assert not isinstance(rec, np.ma.MaskedArray)
-        assert not np.nan in rec
+def test_reconstruction_method_constructor():
+    assert (
+        HankelDMD(reconstruction_method="mean")._reconstruction_method
+        == "mean"
+    )
+    assert HankelDMD(reconstruction_method=[3])._reconstruction_method == [
+        3
+    ]
+    assert all(
+        HankelDMD(
+            reconstruction_method=np.array([1, 2]), d=2
+        )._reconstruction_method
+        == np.array([1, 2])
+    )
 
-    def test_extract_versions_nonan(self):
-        dmd = HankelDMD(d=3)
-        dmd.fit(X=sample_data)
-        for timeindex in range(sample_data.shape[1]):
-            assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
+def test_nonan_nomask():
+    dmd = HankelDMD(d=3)
+    dmd.fit(X=sample_data)
+    rec = dmd.reconstructed_data
 
-    def test_rec_method_first(self):
-        dmd = HankelDMD(d=3, reconstruction_method="first")
-        dmd.fit(X=sample_data)
+    assert not isinstance(rec, np.ma.MaskedArray)
+    assert not np.nan in rec
 
-        rec = dmd.reconstructed_data
-        allrec = dmd.reconstructions_of_timeindex()
-        for i in range(rec.shape[1]):
-            assert (rec[:,i] == allrec[i, min(i,dmd.d-1)]).all()
+def test_extract_versions_nonan():
+    dmd = HankelDMD(d=3)
+    dmd.fit(X=sample_data)
+    for timeindex in range(sample_data.shape[1]):
+        assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
 
-    def test_rec_method_mean(self):
-        dmd = HankelDMD(d=3, reconstruction_method="mean")
-        dmd.fit(X=sample_data)
-        assert (
-            dmd.reconstructed_data.T[2]
-            == np.mean(dmd.reconstructions_of_timeindex(2), axis=0).T
-        ).all()
+def test_rec_method_first():
+    dmd = HankelDMD(d=3, reconstruction_method="first")
+    dmd.fit(X=sample_data)
 
-    def test_rec_method_weighted(self):
-        dmd = HankelDMD(d=2, reconstruction_method=[10, 20])
-        dmd.fit(X=sample_data)
-        assert (
-            dmd.reconstructed_data.T[4]
-            == np.average(
-                dmd.reconstructions_of_timeindex(4), axis=0, weights=[10, 20]
-            ).T
-        ).all()
+    rec = dmd.reconstructed_data
+    allrec = dmd.reconstructions_of_timeindex()
+    for i in range(rec.shape[1]):
+        assert (rec[:,i] == allrec[i, min(i,dmd.d-1)]).all()
 
-    def test_hankeldmd_timesteps(self):
-        x = np.linspace(0, 10, 64)
-        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
-        dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=30).fit(arr)
-        assert len(dmd.dmd_timesteps) == 64
+def test_rec_method_mean():
+    dmd = HankelDMD(d=3, reconstruction_method="mean")
+    dmd.fit(X=sample_data)
+    assert (
+        dmd.reconstructed_data.T[2]
+        == np.mean(dmd.reconstructions_of_timeindex(2), axis=0).T
+    ).all()
 
-    def test_first_occurences(self):
-        x = np.linspace(0, 10, 64)
-        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
-        dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
-        assert dmd._hankel_first_occurrence(0) == 0
-        assert dmd._hankel_first_occurrence(1) == 0
-        assert dmd._hankel_first_occurrence(2) == 0
-        assert dmd._hankel_first_occurrence(3) == 1
-        assert dmd._hankel_first_occurrence(4) == 2
-        assert dmd._hankel_first_occurrence(5) == 3
+def test_rec_method_weighted():
+    dmd = HankelDMD(d=2, reconstruction_method=[10, 20])
+    dmd.fit(X=sample_data)
+    assert (
+        dmd.reconstructed_data.T[4]
+        == np.average(
+            dmd.reconstructions_of_timeindex(4), axis=0, weights=[10, 20]
+        ).T
+    ).all()
 
-        dmd.dmd_time["tend"] = 100
-        assert dmd._hankel_first_occurrence(100) == 98
+def test_hankeldmd_timesteps():
+    x = np.linspace(0, 10, 64)
+    arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+    dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=30).fit(arr)
+    assert len(dmd.dmd_timesteps) == 64
 
-        # change scale
-        dmd.dmd_time["t0"] = dmd.original_time["t0"] = x[0]
-        dmd.dmd_time["tend"] = dmd.original_time["tend"] = x[-1]
-        dmd.dmd_time["dt"] = dmd.original_time["dt"] = x[1] - x[0]
+def test_first_occurences():
+    x = np.linspace(0, 10, 64)
+    arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+    dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
+    assert dmd._hankel_first_occurrence(0) == 0
+    assert dmd._hankel_first_occurrence(1) == 0
+    assert dmd._hankel_first_occurrence(2) == 0
+    assert dmd._hankel_first_occurrence(3) == 1
+    assert dmd._hankel_first_occurrence(4) == 2
+    assert dmd._hankel_first_occurrence(5) == 3
 
-        assert dmd._hankel_first_occurrence(x[0]) == 0
-        assert dmd._hankel_first_occurrence(x[1]) == 0
-        assert dmd._hankel_first_occurrence(x[2]) == 0
-        assert dmd._hankel_first_occurrence(x[3]) == 1
-        assert dmd._hankel_first_occurrence(x[-1] + dmd.dmd_time["dt"]) == 62
+    dmd.dmd_time["tend"] = 100
+    assert dmd._hankel_first_occurrence(100) == 98
 
-        dmd.dmd_time["t0"] = x[len(x) // 2]
-        dmd.dmd_time["tend"] = x[-1] + dmd.dmd_time["dt"] * 20
+    # change scale
+    dmd.dmd_time["t0"] = dmd.original_time["t0"] = x[0]
+    dmd.dmd_time["tend"] = dmd.original_time["tend"] = x[-1]
+    dmd.dmd_time["dt"] = dmd.original_time["dt"] = x[1] - x[0]
 
-        a = dmd._hankel_first_occurrence(dmd.dmd_time["t0"])
-        b = len(x) // 2 - 2
-        assert dmd._hankel_first_occurrence(dmd.dmd_time["t0"]) == len(x) // 2 - 2
+    assert dmd._hankel_first_occurrence(x[0]) == 0
+    assert dmd._hankel_first_occurrence(x[1]) == 0
+    assert dmd._hankel_first_occurrence(x[2]) == 0
+    assert dmd._hankel_first_occurrence(x[3]) == 1
+    assert dmd._hankel_first_occurrence(x[-1] + dmd.dmd_time["dt"]) == 62
 
-    def test_update_sub_dmd_time(self):
-        dmd = HankelDMD()
-        x = np.linspace(0, 10, 64)
-        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
-        dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
+    dmd.dmd_time["t0"] = x[len(x) // 2]
+    dmd.dmd_time["tend"] = x[-1] + dmd.dmd_time["dt"] * 20
 
-        dmd.dmd_time["tend"] += dmd.dmd_time["dt"] * 20
-        dmd._update_sub_dmd_time()
+    a = dmd._hankel_first_occurrence(dmd.dmd_time["t0"])
+    b = len(x) // 2 - 2
+    assert dmd._hankel_first_occurrence(dmd.dmd_time["t0"]) == len(x) // 2 - 2
 
-        # assert that the dt for the sub_dmd is always 1
-        assert dmd._sub_dmd.dmd_time["dt"] == 1
-        assert dmd._sub_dmd.original_time["dt"] == 1
+def test_update_sub_dmd_time():
+    dmd = HankelDMD()
+    x = np.linspace(0, 10, 64)
+    arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+    dmd = HankelDMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
 
-        assert (
-            dmd._sub_dmd.dmd_time["tend"]
-            == dmd._sub_dmd.original_time["tend"] + 20
-        )
+    dmd.dmd_time["tend"] += dmd.dmd_time["dt"] * 20
+    dmd._update_sub_dmd_time()
 
-    def test_hankel_2d(self):
-        def fnc(x):
-            return np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+    # assert that the dt for the sub_dmd is always 1
+    assert dmd._sub_dmd.dmd_time["dt"] == 1
+    assert dmd._sub_dmd.original_time["dt"] == 1
 
-        x = np.linspace(0, 10, 64)
-        snapshots = np.vstack([fnc(x), -fnc(x)])
+    assert (
+        dmd._sub_dmd.dmd_time["tend"]
+        == dmd._sub_dmd.original_time["tend"] + 20
+    )
 
-        dmd = HankelDMD(svd_rank=0, exact=True, opt=True, d=30).fit(snapshots)
+def test_hankel_2d():
+    def fnc(x):
+        return np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
 
-        dmd.original_time["dt"] = dmd.dmd_time["dt"] = x[1] - x[0]
-        dmd.original_time["t0"] = dmd.dmd_time["t0"] = x[0]
-        dmd.original_time["tend"] = dmd.dmd_time["tend"] = x[-1]
+    x = np.linspace(0, 10, 64)
+    snapshots = np.vstack([fnc(x), -fnc(x)])
 
-        dmd.dmd_time["t0"] = x[len(x) // 2]
-        dmd.dmd_time["tend"] = x[-1] + dmd.dmd_time["dt"] * 20
+    dmd = HankelDMD(svd_rank=0, exact=True, opt=True, d=30).fit(snapshots)
 
-        assert len(dmd.dmd_timesteps) == dmd.reconstructed_data.shape[1]
+    dmd.original_time["dt"] = dmd.dmd_time["dt"] = x[1] - x[0]
+    dmd.original_time["t0"] = dmd.dmd_time["t0"] = x[0]
+    dmd.original_time["tend"] = dmd.dmd_time["tend"] = x[-1]
 
-        np.testing.assert_allclose(
-            dmd.reconstructed_data,
-            np.vstack([fnc(dmd.dmd_timesteps), -fnc(dmd.dmd_timesteps)]),
-        )
+    dmd.dmd_time["t0"] = x[len(x) // 2]
+    dmd.dmd_time["tend"] = x[-1] + dmd.dmd_time["dt"] * 20
 
-    def test_get_bitmask_default(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        assert np.all(dmd.modes_activation_bitmask == True)
+    assert len(dmd.dmd_timesteps) == dmd.reconstructed_data.shape[1]
 
-    def test_set_bitmask(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+    np.testing.assert_allclose(
+        dmd.reconstructed_data,
+        np.vstack([fnc(dmd.dmd_timesteps), -fnc(dmd.dmd_timesteps)]),
+    )
 
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_get_bitmask_default():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    assert np.all(dmd.modes_activation_bitmask == True)
 
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
+def test_set_bitmask():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
 
-    def test_raise_wrong_dtype_bitmask(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
+def test_not_fitted_get_bitmask_raises():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
 
-    def test_fitted(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        assert not dmd.fitted
-        dmd.fit(X=sample_data)
-        assert dmd.fitted
+def test_not_fitted_set_bitmask_raises():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
 
-    def test_bitmask_amplitudes(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_raise_wrong_dtype_bitmask():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
 
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+def test_fitted():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    assert not dmd.fitted
+    dmd.fit(X=sample_data)
+    assert dmd.fitted
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_bitmask_amplitudes():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
 
-    def test_bitmask_eigs(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_bitmask_eigs():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
 
-    def test_bitmask_modes(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_bitmask_modes():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
 
-    def test_reconstructed_data(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-        dmd.reconstructed_data
-        assert True
+def test_reconstructed_data():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-    def test_getitem_modes(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        old_n_modes = dmd.modes.shape[1]
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+    dmd.reconstructed_data
+    assert True
 
-        assert dmd.modes.shape[1] == old_n_modes
+def test_getitem_modes():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    old_n_modes = dmd.modes.shape[1]
 
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[[1,3]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[2].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+    assert dmd[[1,3]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-    def test_getitem_raises(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+    assert dmd[2].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
 
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
+    assert dmd.modes.shape[1] == old_n_modes
 
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        dmd = HankelDMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._sub_dmd._b)
+def test_getitem_raises():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
+
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._sub_dmd._b)
+
+def test_raises_not_enough_snapshots():
+    dmd = HankelDMD(svd_rank=-1, d=5)
+    with raises(ValueError,  match="The number of snapshots provided is not enough for d=5.\nExpected at least d."):
+        dmd.fit(np.ones((20,4)))
+    dmd.fit(np.ones((20,5)))

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -1,10 +1,9 @@
 from builtins import range
-from unittest import TestCase
+from pytest import raises
 from pydmd.hodmd import HODMD
 import matplotlib.pyplot as plt
 import numpy as np
 import os
-import pytest
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -33,451 +32,456 @@ def create_noisy_data():
 noisy_data = create_noisy_data()
 
 
-class TestHODmd(TestCase):
-    def test_shape(self):
-        dmd = HODMD(svd_rank=-1, d=2, svd_rank_extra=-1)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == sample_data.shape[1] - 2
+def test_shape():
+    dmd = HODMD(svd_rank=-1, d=2, svd_rank_extra=-1)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == sample_data.shape[1] - 2
 
-    def test_truncation_shape(self):
-        dmd = HODMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == 3
+def test_truncation_shape():
+    dmd = HODMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == 3
 
-    def test_rank(self):
-        dmd = HODMD(svd_rank=0.9)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 2
+def test_rank():
+    dmd = HODMD(svd_rank=0.9)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 2
 
-    def test_Atilde_shape(self):
-        dmd = HODMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
+def test_Atilde_shape():
+    dmd = HODMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
 
-    def test_d(self):
-        single_data = np.sin(np.linspace(0, 10, 100))
-        dmd = HODMD(svd_rank=-1, d=50, opt=True, exact=True, svd_rank_extra=-1)
-        dmd.fit(single_data)
-        assert np.allclose(dmd.reconstructed_data.flatten(), single_data)
-        assert dmd.d == 50
+def test_d():
+    single_data = np.sin(np.linspace(0, 10, 100))
+    dmd = HODMD(svd_rank=-1, d=50, opt=True, exact=True, svd_rank_extra=-1)
+    dmd.fit(single_data)
+    assert np.allclose(dmd.reconstructed_data.flatten(), single_data)
+    assert dmd.d == 50
 
-    def test_Atilde_values(self):
-        dmd = HODMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        exact_atilde = np.array(
-            [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
-             [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
-        np.testing.assert_allclose(exact_atilde, dmd.atilde)
+def test_Atilde_values():
+    dmd = HODMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    exact_atilde = np.array(
+        [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
+            [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
+    np.testing.assert_allclose(exact_atilde, dmd.atilde)
 
-    def test_eigs_1(self):
-        dmd = HODMD(svd_rank=-1, svd_rank_extra=-1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 14
+def test_eigs_1():
+    dmd = HODMD(svd_rank=-1, svd_rank_extra=-1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 14
 
-    def test_eigs_2(self):
-        dmd = HODMD(svd_rank=5, svd_rank_extra=-1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 5
+def test_eigs_2():
+    dmd = HODMD(svd_rank=5, svd_rank_extra=-1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 5
 
-    def test_eigs_3(self):
-        dmd = HODMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_eigs = np.array([
-            -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
-        ])
-        np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
+def test_eigs_3():
+    dmd = HODMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_eigs = np.array([
+        -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
+    ])
+    np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
 
-    def test_eigs_4(self):
-        dmd = HODMD(svd_rank=5, svd_rank_extra=4)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 4
+def test_eigs_4():
+    dmd = HODMD(svd_rank=5, svd_rank_extra=4)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 4
 
-    def test_dynamics_1(self):
-        dmd = HODMD(svd_rank=5, svd_rank_extra=-1)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
+def test_dynamics_1():
+    dmd = HODMD(svd_rank=5, svd_rank_extra=-1)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
 
-    def test_dynamics_2(self):
-        dmd = HODMD(svd_rank=5, svd_rank_extra=4)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (4, sample_data.shape[1])
+def test_dynamics_2():
+    dmd = HODMD(svd_rank=5, svd_rank_extra=4)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (4, sample_data.shape[1])
 
-    def test_dynamics_opt_1(self):
-        dmd = HODMD(svd_rank=5, svd_rank_extra=-1, opt=True)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
+def test_dynamics_opt_1():
+    dmd = HODMD(svd_rank=5, svd_rank_extra=-1, opt=True)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
 
-    def test_dynamics_opt_2(self):
-        dmd = HODMD(svd_rank=5, svd_rank_extra=4, opt=True)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (4, sample_data.shape[1])
+def test_dynamics_opt_2():
+    dmd = HODMD(svd_rank=5, svd_rank_extra=4, opt=True)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (4, sample_data.shape[1])
 
-    def test_reconstructed_data(self):
-        dmd = HODMD(d=2)
-        dmd.fit(X=sample_data)
-        dmd.reconstructions_of_timeindex(2)
-        dmd_data = dmd.reconstructed_data
-        np.testing.assert_allclose(dmd_data, sample_data)
+def test_reconstructed_data():
+    dmd = HODMD(d=2)
+    dmd.fit(X=sample_data)
+    dmd.reconstructions_of_timeindex(2)
+    dmd_data = dmd.reconstructed_data
+    np.testing.assert_allclose(dmd_data, sample_data)
 
-    def test_original_time(self):
-        dmd = HODMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
-        np.testing.assert_equal(dmd.original_time, expected_dict)
+def test_original_time():
+    dmd = HODMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+    np.testing.assert_equal(dmd.original_time, expected_dict)
 
-    def test_original_timesteps(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        np.testing.assert_allclose(dmd.original_timesteps,
-                                   np.arange(sample_data.shape[1]))
+def test_original_timesteps():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    np.testing.assert_allclose(dmd.original_timesteps,
+                                np.arange(sample_data.shape[1]))
 
-    def test_dmd_time_1(self):
-        dmd = HODMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
-        np.testing.assert_equal(dmd.dmd_time, expected_dict)
+def test_dmd_time_1():
+    dmd = HODMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+    np.testing.assert_equal(dmd.dmd_time, expected_dict)
 
-    def test_dmd_time_2(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 10
-        dmd.dmd_time['tend'] = 14
-        expected_data = sample_data[:, -5:]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+def test_dmd_time_2():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 10
+    dmd.dmd_time['tend'] = 14
+    expected_data = sample_data[:, -5:]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
-    def test_dmd_time_3(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 8
-        dmd.dmd_time['tend'] = 11
-        expected_data = sample_data[:, 8:12]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+def test_dmd_time_3():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 8
+    dmd.dmd_time['tend'] = 11
+    expected_data = sample_data[:, 8:12]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
-    def test_dmd_time_4(self):
-        dmd = HODMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 20
-        dmd.dmd_time['tend'] = 20
-        expected_data = np.array([[7.29383297e+00 + 0.0j],
-                                  [5.69109796e+00 + 2.74068833e+00j],
-                                  [           0.0 + 0.0j]])
-        np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
+def test_dmd_time_4():
+    dmd = HODMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 20
+    dmd.dmd_time['tend'] = 20
+    expected_data = np.array([[7.29383297e+00 + 0.0j],
+                                [5.69109796e+00 + 2.74068833e+00j],
+                                [           0.0 + 0.0j]])
+    np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
 
-    def test_dmd_time_5(self):
-        x = np.linspace(0, 10, 64)
-        y = np.cos(x)*np.sin(np.cos(x)) + np.cos(x*.2)
+def test_dmd_time_5():
+    x = np.linspace(0, 10, 64)
+    y = np.cos(x)*np.sin(np.cos(x)) + np.cos(x*.2)
 
-        dmd = HODMD(svd_rank=-1, exact=True, opt=True, d=30, svd_rank_extra=-1)
-        dmd.fit(y)
+    dmd = HODMD(svd_rank=-1, exact=True, opt=True, d=30, svd_rank_extra=-1)
+    dmd.fit(y)
 
-        dmd.original_time['dt'] = dmd.dmd_time['dt'] = x[1] - x[0]
-        dmd.original_time['t0'] = dmd.dmd_time['t0'] = x[0]
-        dmd.original_time['tend'] = dmd.dmd_time['tend'] = x[-1]
+    dmd.original_time['dt'] = dmd.dmd_time['dt'] = x[1] - x[0]
+    dmd.original_time['t0'] = dmd.dmd_time['t0'] = x[0]
+    dmd.original_time['tend'] = dmd.dmd_time['tend'] = x[-1]
 
-        # assert that the shape of the output is correct
-        assert dmd.reconstructed_data.shape == (1,64)
+    # assert that the shape of the output is correct
+    assert dmd.reconstructed_data.shape == (1,64)
 
-    def test_plot_eigs_1(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=True, show_unit_circle=True)
-        plt.close()
+def test_plot_eigs_1():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=True, show_unit_circle=True)
+    plt.close()
 
-    def test_plot_eigs_2(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_eigs_2():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
 
-    """
-    def test_plot_modes_1(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_modes_2D()
-
-    def test_plot_modes_2(self):
-        dmd = HODMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_modes_2D((1, 2, 5), x=np.arange(1), y=np.arange(15))
-        plt.close()
-
-    def test_plot_modes_3(self):
-        dmd = HODMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
+"""
+def test_plot_modes_1():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
         dmd.plot_modes_2D()
-        plt.close()
 
-    def test_plot_modes_4(self):
-        dmd = HODMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1)
-        plt.close()
+def test_plot_modes_2():
+    dmd = HODMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_modes_2D((1, 2, 5), x=np.arange(1), y=np.arange(15))
+    plt.close()
 
-    def test_plot_modes_5(self):
-        dmd = HODMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.1.png')
-    """
+def test_plot_modes_3():
+    dmd = HODMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D()
+    plt.close()
 
-    def test_plot_snapshots_1(self):
-        dmd = HODMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_snapshots_2D()
+def test_plot_modes_4():
+    dmd = HODMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1)
+    plt.close()
 
-    def test_plot_snapshots_2(self):
-        dmd = HODMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
+def test_plot_modes_5():
+    dmd = HODMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
+    os.remove('tmp.1.png')
+"""
 
-    def test_plot_snapshots_3(self):
-        dmd = HODMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
+def test_plot_snapshots_1():
+    dmd = HODMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
         dmd.plot_snapshots_2D()
-        plt.close()
 
-    def test_plot_snapshots_4(self):
-        dmd = HODMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2)
-        plt.close()
+def test_plot_snapshots_2():
+    dmd = HODMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
 
-    def test_plot_snapshots_5(self):
-        dmd = HODMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.2.png')
+def test_plot_snapshots_3():
+    dmd = HODMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D()
+    plt.close()
 
-    def test_tdmd_plot(self):
-        dmd = HODMD(tlsq_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_snapshots_4():
+    dmd = HODMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2)
+    plt.close()
 
-    def test_sorted_eigs_default(self):
-        dmd = HODMD()
-        assert dmd.operator._sorted_eigs == False
+def test_plot_snapshots_5():
+    dmd = HODMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
+    os.remove('tmp.2.png')
 
-    def test_sorted_eigs_param(self):
-        dmd = HODMD(sorted_eigs='real')
-        assert dmd.operator._sorted_eigs == 'real'
+def test_tdmd_plot():
+    dmd = HODMD(tlsq_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
+
+def test_sorted_eigs_default():
+    dmd = HODMD()
+    assert dmd.operator._sorted_eigs == False
+
+def test_sorted_eigs_param():
+    dmd = HODMD(sorted_eigs='real')
+    assert dmd.operator._sorted_eigs == 'real'
 
 
-    def test_reconstruction_method_constructor_error(self):
-        with self.assertRaises(ValueError):
-            HODMD(reconstruction_method=[1, 2, 3], d=4)
+def test_reconstruction_method_constructor_error():
+    with raises(ValueError):
+        HODMD(reconstruction_method=[1, 2, 3], d=4)
 
-        with self.assertRaises(ValueError):
-            HODMD(reconstruction_method=np.array([1, 2, 3]), d=4)
+    with raises(ValueError):
+        HODMD(reconstruction_method=np.array([1, 2, 3]), d=4)
 
-        with self.assertRaises(ValueError):
-            HODMD(reconstruction_method=np.array([[1, 2, 3], [3, 4, 5]]), d=3)
+    with raises(ValueError):
+        HODMD(reconstruction_method=np.array([[1, 2, 3], [3, 4, 5]]), d=3)
 
 
-    def test_reconstruction_method_default_constructor(self):
-        assert HODMD()._reconstruction_method == 'first'
+def test_reconstruction_method_default_constructor():
+    assert HODMD()._reconstruction_method == 'first'
 
-    def test_reconstruction_method_constructor(self):
-        assert HODMD(reconstruction_method='mean')._reconstruction_method == 'mean'
-        assert HODMD(reconstruction_method=[3])._reconstruction_method == [3]
-        assert all(HODMD(reconstruction_method=np.array([1, 2]), d=2)._reconstruction_method == np.array([1, 2]))
+def test_reconstruction_method_constructor():
+    assert HODMD(reconstruction_method='mean')._reconstruction_method == 'mean'
+    assert HODMD(reconstruction_method=[3])._reconstruction_method == [3]
+    assert all(HODMD(reconstruction_method=np.array([1, 2]), d=2)._reconstruction_method == np.array([1, 2]))
 
-    def test_nonan_nomask(self):
-        dmd = HODMD(d=3)
-        dmd.fit(X=sample_data)
-        rec = dmd.reconstructed_data
+def test_nonan_nomask():
+    dmd = HODMD(d=3)
+    dmd.fit(X=sample_data)
+    rec = dmd.reconstructed_data
 
-        assert not isinstance(rec, np.ma.MaskedArray)
-        assert not np.nan in rec
+    assert not isinstance(rec, np.ma.MaskedArray)
+    assert not np.nan in rec
 
-    def test_extract_versions_nonan(self):
-        dmd = HODMD(d=3)
-        dmd.fit(X=sample_data)
-        for timeindex in range(sample_data.shape[1]):
-            assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
+def test_extract_versions_nonan():
+    dmd = HODMD(d=3)
+    dmd.fit(X=sample_data)
+    for timeindex in range(sample_data.shape[1]):
+        assert not np.nan in dmd.reconstructions_of_timeindex(timeindex)
 
-    def test_rec_method_first(self):
-        dmd = HODMD(d=3, reconstruction_method="first")
-        dmd.fit(X=sample_data)
+def test_rec_method_first():
+    dmd = HODMD(d=3, reconstruction_method="first")
+    dmd.fit(X=sample_data)
 
-        rec = dmd.reconstructed_data
-        allrec = dmd.reconstructions_of_timeindex()
-        for i in range(rec.shape[1]):
-            assert (rec[:,i] == allrec[i, min(i,dmd.d-1)]).all()
+    rec = dmd.reconstructed_data
+    allrec = dmd.reconstructions_of_timeindex()
+    for i in range(rec.shape[1]):
+        assert (rec[:,i] == allrec[i, min(i,dmd.d-1)]).all()
 
-    def test_rec_method_mean(self):
-        dmd = HODMD(d=3, reconstruction_method='mean')
-        dmd.fit(X=sample_data)
-        assert (dmd.reconstructed_data.T[2] == np.mean(dmd.reconstructions_of_timeindex(2), axis=0).T).all()
+def test_rec_method_mean():
+    dmd = HODMD(d=3, reconstruction_method='mean')
+    dmd.fit(X=sample_data)
+    assert (dmd.reconstructed_data.T[2] == np.mean(dmd.reconstructions_of_timeindex(2), axis=0).T).all()
 
-    def test_rec_method_weighted(self):
-        dmd = HODMD(d=2, svd_rank_extra=-1,reconstruction_method=[10,20])
-        dmd.fit(X=sample_data)
-        assert (dmd.reconstructed_data.T[4] == np.average(dmd.reconstructions_of_timeindex(4), axis=0, weights=[10,20]).T).all()
-    """
-    def test_dynamics_opt_2(self):
-        dmd = HODMD(svd_rank=1, opt=True)
-        dmd.fit(X=sample_data)
-        expected_dynamics = np.array([[
-            -5.03688923-6.13804898j,  7.71392231+0.99781981j,
-            -6.17317754+4.46645858j, 1.40580999-7.33054163j,
-            3.91802381+6.17354485j, -6.93951835-1.77423468j,
-            6.14189948-3.39268579j, -2.10431578+6.54348298j,
-            -2.89133864-6.08093842j, 6.14488387+2.39737718j,
-            -5.99329708+2.41468142j,  2.6548298 -5.74598891j,
-            1.96322997+5.8815406j, -5.34888809-2.87815739j,
-            5.74815609-1.53732875j
-        ]])
-        np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
-    """
+def test_rec_method_weighted():
+    dmd = HODMD(d=2, svd_rank_extra=-1,reconstruction_method=[10,20])
+    dmd.fit(X=sample_data)
+    assert (dmd.reconstructed_data.T[4] == np.average(dmd.reconstructions_of_timeindex(4), axis=0, weights=[10,20]).T).all()
+"""
+def test_dynamics_opt_2():
+    dmd = HODMD(svd_rank=1, opt=True)
+    dmd.fit(X=sample_data)
+    expected_dynamics = np.array([[
+        -5.03688923-6.13804898j,  7.71392231+0.99781981j,
+        -6.17317754+4.46645858j, 1.40580999-7.33054163j,
+        3.91802381+6.17354485j, -6.93951835-1.77423468j,
+        6.14189948-3.39268579j, -2.10431578+6.54348298j,
+        -2.89133864-6.08093842j, 6.14488387+2.39737718j,
+        -5.99329708+2.41468142j,  2.6548298 -5.74598891j,
+        1.96322997+5.8815406j, -5.34888809-2.87815739j,
+        5.74815609-1.53732875j
+    ]])
+    np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
+"""
 
-    def test_scalar_func_warning(self):
-        x = np.linspace(0, 10, 64)
-        arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
-        # we check that this does not fail
-        dmd = HODMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
+def test_scalar_func_warning():
+    x = np.linspace(0, 10, 64)
+    arr = np.cos(x) * np.sin(np.cos(x)) + np.cos(x * 0.2)
+    # we check that this does not fail
+    dmd = HODMD(svd_rank=1, exact=True, opt=True, d=3).fit(arr)
 
-    def test_get_bitmask_default(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        assert np.all(dmd.modes_activation_bitmask == True)
+def test_get_bitmask_default():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    assert np.all(dmd.modes_activation_bitmask == True)
 
-    def test_set_bitmask(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_set_bitmask():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
 
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
+def test_not_fitted_get_bitmask_raises():
+    dmd = HODMD(svd_rank=-1, d=5)
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
 
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+def test_not_fitted_set_bitmask_raises():
+    dmd = HODMD(svd_rank=-1, d=5)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
 
-    def test_raise_wrong_dtype_bitmask(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
+def test_raise_wrong_dtype_bitmask():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
 
-    def test_fitted(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        assert not dmd.fitted
-        dmd.fit(X=sample_data)
-        assert dmd.fitted
+def test_fitted():
+    dmd = HODMD(svd_rank=-1, d=5)
+    assert not dmd.fitted
+    dmd.fit(X=sample_data)
+    assert dmd.fitted
 
-    def test_bitmask_amplitudes(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_bitmask_amplitudes():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
 
-    def test_bitmask_eigs(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_bitmask_eigs():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
 
-    def test_bitmask_modes(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_bitmask_modes():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-    def test_reconstructed_data(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_reconstructed_data():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        dmd.reconstructed_data
-        assert True
+    dmd.reconstructed_data
+    assert True
 
-    def test_getitem_modes(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        old_n_modes = dmd.modes.shape[1]
+def test_getitem_modes():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    old_n_modes = dmd.modes.shape[1]
 
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[[1,3]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+    assert dmd[[1,3]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[2].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+    assert dmd[2].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-    def test_getitem_raises(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
+def test_getitem_raises():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
 
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
 
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        dmd = HODMD(svd_rank=-1, d=5)
-        dmd.fit(X=sample_data)
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._sub_dmd._b)
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    dmd = HODMD(svd_rank=-1, d=5)
+    dmd.fit(X=sample_data)
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._sub_dmd._b)
+
+def test_raises_not_enough_snapshots():
+    dmd = HODMD(svd_rank=-1, d=5)
+    with raises(ValueError,  match="The number of snapshots provided is not enough for d=5.\nExpected at least d."):
+        dmd.fit(np.ones((20,4)))
+    dmd.fit(np.ones((20,5)))


### PR DESCRIPTION
This commit improves the error message shown by `HankelDMD` and `HODMD` when the number of snapshots is not sufficient to form a proper Hankel's pseudo-matrix.

```python
>>> HankelDMD(d=5).fit(np.ones((20,4)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/francescoandreuzzi/Programming/SISSA/PyDMD/pydmd/hankeldmd.py", line 342, in fit
    raise ValueError(msg.format(self._d))
ValueError: The number of snapshots provided is not enough for d=5.
Expected at least d.
```

Fixes #259 