### PR TITLE
Use `np.lib.stride_tricks.sliding_window_view` for pseudo Hankel matrix

### DIFF
--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -9,6 +9,7 @@ Applied Dynamical Systems, 2017, 16.4: 2096-2126.
 from copy import copy
 
 import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view as swv
 
 from .dmdbase import DMDBase
 from .dmd import DMD
@@ -260,9 +261,10 @@ class HankelDMD(DMDBase):
                    [4, 5]])
 
         """
-        return np.concatenate(
-            [X[:, i : X.shape[1] - self.d + i + 1] for i in range(self.d)],
-            axis=0,
+        return (
+            swv(X.T, (self.d, X.shape[0]))[:, 0]
+            .reshape(X.shape[1] - self.d + 1, -1)
+            .T
         )
 
     @property


### PR DESCRIPTION
In this PR I modified `HankelDMD._pseudo_hankel_matrix` in order to use [`numpy.lib.stride_tricks.sliding_window_view`](https://numpy.org/devdocs/reference/generated/numpy.lib.stride_tricks.sliding_window_view.html) (and avoid Python lists). As you can see below there isn't a huge performance improvement, but I think this is the nearest full-NumPy method to do what we need here, therefore I feel like it's more interesting to do this instead of the usual `np.concatenate`.

### My experiments
The best overall (the one I use in this PR) is `stride_version2`:
```python
def numpy_version(X, d):
    n_ho_snapshots = X.shape[1] - d + 1

    idxes = np.repeat(
        np.arange(d)[None], repeats=n_ho_snapshots, axis=0
    )
    idxes += np.arange(n_ho_snapshots)[:,None]
    return X.T[idxes].reshape(-1, X.shape[0] * d).T

def numpy_version2(X, d):
    n_ho_snapshots = X.shape[1] - d + 1

    idxes = np.repeat(
        np.arange(d)[None], repeats=n_ho_snapshots, axis=0
    )
    idxes += np.arange(n_ho_snapshots)[:,None]
    return np.swapaxes(X[:,idxes],1,2).reshape(-1, X.shape[0] * d, order='F')

def numpy_version3(X, d):
    n_ho_snapshots = X.shape[1] - d + 1

    idxes = np.repeat(
        np.arange(d)[None], repeats=n_ho_snapshots, axis=0
    )
    idxes += np.arange(n_ho_snapshots)[:,None]
    return np.swapaxes(X[:,idxes],0,1).reshape(-1, X.shape[0] * d).T

def numpy_version3(X, d):
    n_ho_snapshots = X.shape[1] - d + 1

    idxes = np.repeat(
        np.arange(d)[None], repeats=n_ho_snapshots, axis=0
    )
    idxes += np.arange(n_ho_snapshots)[:,None]
    idxes = idxes.flatten()
    return np.swapaxes(X[:,idxes],0,1).reshape(-1, X.shape[0] * d).T

def numpy_version4(X, d):
    n_ho_snapshots = X.shape[1] - d + 1

    idxes = np.repeat(
        np.arange(d)[None], repeats=n_ho_snapshots, axis=0
    )
    idxes += np.arange(n_ho_snapshots)[:,None]
    return X[:, idxes.flatten()].reshape(X.shape[0] * d, -1, order='F')

def stride_version(X, d):
    n_ho_snapshots = X.shape[1] - d + 1
    return swv(X, (X.shape[0], d))[0].reshape(n_ho_snapshots, -1, order='F').T

def stride_version2(X, d): # <-
    n_ho_snapshots = X.shape[1] - d + 1
    return swv(X.T, (d, X.shape[0]))[:,0].reshape(n_ho_snapshots, -1).T

def python_list_version(X, d):
    return np.concatenate(
            [X[:, i : X.shape[1] - d + i + 1] for i in range(d)],
            axis=0,
    )
```

### Results
```python
X = np.ones((500, 1000))
d = 10

%timeit numpy_version(X,d)
%timeit numpy_version2(X,d)
%timeit numpy_version3(X,d)
%timeit numpy_version4(X,d)
%timeit stride_version(X,d)
%timeit stride_version2(X,d) # <-
%timeit python_list_version(X,d)

print('-----')

X = np.ones((500, 1000))
d = 100

%timeit numpy_version(X,d)
%timeit numpy_version2(X,d)
%timeit numpy_version3(X,d)
%timeit numpy_version4(X,d)
%timeit stride_version(X,d)
%timeit stride_version2(X,d) # <-
%timeit python_list_version(X,d)

print('-----')

X = np.ones((500, 10000))
d = 100

%timeit numpy_version(X,d)
%timeit numpy_version2(X,d)
%timeit numpy_version3(X,d)
%timeit numpy_version4(X,d)
%timeit stride_version(X,d)
%timeit stride_version2(X,d) # <-
%timeit python_list_version(X,d)
```
```
7.71 ms ± 2.26 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.72 ms ± 1.83 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.73 ms ± 2.08 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.73 ms ± 1.97 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.67 ms ± 4.36 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.58 ms ± 4.44 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) <-
7.63 ms ± 4.48 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
-----
67.3 ms ± 18.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
67.3 ms ± 24.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
67.4 ms ± 37.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
67.5 ms ± 24.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
66.5 ms ± 31.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
64.9 ms ± 17.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each) <-
67 ms ± 36.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
-----
754 ms ± 334 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
754 ms ± 158 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
757 ms ± 618 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
757 ms ± 2.51 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
744 ms ± 424 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
742 ms ± 147 µs per loop (mean ± std. dev. of 7 runs, 1 loop each) <-
744 ms ± 202 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```