### PR TITLE
[ParamDMD] Improve error message shown when `parameters` is empty

### DIFF
--- a/pydmd/paramdmd.py
+++ b/pydmd/paramdmd.py
@@ -519,6 +519,12 @@ Property not available now, did you call `fit()`?"""
             untested parameters.
         :rtype: numpy.ndarray
         """
+        if self.parameters is None or len(self.parameters) == 0:
+            raise ValueError(
+                """
+Unknown parameters not found. Did you set `ParametricDMD.parameters`?"""
+            )
+
         if forecasted_modal_coefficients.shape[1] != len(self.dmd_timesteps):
             raise ValueError(
                 "Invalid number of time instants provided: "

--- a/tests/test_paramdmd.py
+++ b/tests/test_paramdmd.py
@@ -523,3 +523,12 @@ def test_interpolated_modal_coefficients_reshape_monolithic():
     )
     np.testing.assert_allclose(p.interpolated_modal_coefficients[1,3], interpolated_modal_coefficients[:,1,3])
     np.testing.assert_allclose(p.interpolated_modal_coefficients[2,0], interpolated_modal_coefficients[:,2,0])
+
+def test_no_parameters_error():
+    dmds = DMD(svd_rank=-1)
+    p = ParametricDMD(dmds, POD(rank=5), RBF(), light=True)
+    p.fit(training_data, params)
+    p.dmd_time['tend'] += 100
+
+    with raises(ValueError, match='Unknown parameters not found. Did you set `ParametricDMD.parameters`?'):
+        p.reconstructed_data


### PR DESCRIPTION
Fixes #273 