### PR TITLE
[ParamDMD] Enforce PyDMD shape convention

### DIFF
--- a/tutorials/tutorial10/tutorial-10-paramdmd.ipynb
+++ b/tutorials/tutorial10/tutorial-10-paramdmd.ipynb
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "id": "spiritual-excuse",
    "metadata": {},
    "outputs": [
@@ -121,7 +121,7 @@
      "output_type": "stream",
      "text": [
       "[0.  0.1 0.2 0.3 0.4 0.6 0.7 0.8 0.9 1. ]\n",
-      "(10, 160, 500)\n"
+      "(10, 500, 160)\n"
      ]
     }
    ],
@@ -129,7 +129,7 @@
     "training_params = np.round(np.linspace(0,1,10),1)\n",
     "print(training_params)\n",
     "\n",
-    "training_snapshots = np.array([f(p)(xgrid, tgrid) for p in training_params])\n",
+    "training_snapshots = np.array([f(p)(xgrid, tgrid).T for p in training_params])\n",
     "print(training_snapshots.shape)"
    ]
   },
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "id": "statutory-tampa",
    "metadata": {},
    "outputs": [],
@@ -156,9 +156,9 @@
     "    if labels_func != None:\n",
     "        labels_func(ax)\n",
     "    if log:\n",
-    "        return ax.pcolormesh(X.real, norm=colors.LogNorm(vmin=X.min(), vmax=X.max()))\n",
+    "        return ax.pcolormesh(X.real.T, norm=colors.LogNorm(vmin=X.min(), vmax=X.max()))\n",
     "    else:\n",
-    "        return ax.pcolormesh(X.real)\n",
+    "        return ax.pcolormesh(X.real.T)\n",
     "\n",
     "def visualize_multiple(Xs, params, log=False, figsize=(20,6), labels_func=None):\n",
     "    if log:\n",
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "id": "alone-advice",
    "metadata": {},
    "outputs": [
@@ -219,17 +219,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 27,
    "id": "mysterious-heath",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(80,)\n"
-     ]
-    },
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdAAAACsCAYAAADLyv0OAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAAXrElEQVR4nO3de3hU9Z3H8fc3IZhEUmKJlwaUoLUUwQsXLT5q1SJyWYu26yJr3VXXK3b1aWtTYUVUbKtb2j7q01XRykOVp1W8LOKCgheoWkENNwVF8YKQRAWiQdCABL/7xznBSTITJieTueDn9TzzMHMuv/Od3xnmk/M7Jznm7oiIiEj75GW6ABERkVykABUREYlAASoiIhKBAlRERCQCBaiIiEgEClAREZEIFKDSqczsLjO7LkVtHWJm28wsP3y9yMwuTkXbYXtPmNn5qWqvHdv9tZltNrMPk1z+BjOb2dl1iUjbFKASmZmtM7MGM9tqZvVm9qKZXW5muz9X7n65u9+UZFuntbWMu693927uvisFtbcKIXcf5e5/6Wjb7azjEOBq4Ah3PyjO/FPMrDqdNeWKZD4zIp1JASod9UN3LwF6A7cA1wD3pnojZtYl1W1miUOAOnffmOlCOiqX9pEF9P0nHaIPkKSEu29x9znAOcD5ZjYAwMxmmNmvw+dlZvZ/4dHqx2b2vJnlmdn9BEHyeDhE+yszqzAzN7OLzGw98GzMtNgv6sPM7GUz+9TMHjOzb4bbanXk1nTEYmYjgf8Czgm3tzKcv3tIOKxrkpm9b2Ybzew+M+sezmuq43wzWx8Ov16bqG/MrHu4/qawvUlh+6cBTwHlYR0zWqy3L/BEzPxtZlYezu4atrnVzFab2ZCY9crN7JFwe++Z2VVt1DYjHGZ/Kmzr72bWO2b+bWa2IezfpWZ2Usy8G8zsYTObaWafAheY2XFmtjjcxx+Y2Z/MrGvMOm5mV5jZ2nB7N5nZYeHoxadmNqvF8meY2YqYEY6jwumtPjPh9KHhcvVmttLMTolpa5GZ/cbM/gF8DhxqZheY2bthLe+Z2U8S9ZVIK+6uhx6RHsA64LQ409cD48PnM4Bfh89vBu4CCsLHSYDFawuoABy4D9gXKIqZ1iVcZhFQAwwIl3kEmBnOOwWoTlQvcEPTsjHzFwEXh8//A3gbOBToBjwK3N+itnvCuo4GdgD9EvTTfcBjQEm47lvARYnqbLFuvPdxA7AdGA3kh/26JJyXBywFJgNdw/rfBUYkaH8GsBX4PrAPcBvwQsz884AeQBeCoeYPgcKYOnYCZ4XbLQIGA0PD5SuAN4CfxbTnYV98A+gf9tszYZ3dgdeB88NlBwIbge+F7/P8cB/uk+Az0xOoC/slDxgevt4/Zv+uD7fbJdzep0DfcP63gP6Z/n+lR+48dAQqnaEW+Gac6TsJvqR6u/tOd3/e3ff0x5hvcPfP3L0hwfz73X2Vu38GXAeMtfAiow76CfBHd3/X3bcBE4FxLY5+b3T3BndfCawkCNJmwlrGARPdfau7rwP+APxbB+t7wd3neXA++P6YbR9LEBhT3P0Ld3+XIOjHtdHWXHd/zt13ANcCx5vZwQDuPtPd69y90d3/QBCyfWPWXezus939y7Avlrr7knD5dcA04OQW2/udu3/q7quBVcCCsJ+3EBxxDwyXuxSY5u4vufsuD85P7yAI6HjOA+aF/fKluz8FVBEEapMZ7r7a3RuBRuBLYICZFbn7B2FNIklRgEpn6Al8HGf6VIKjugXhsNmEJNra0I757xMc2ZYlVWXbysP2YtvuAhwYMy32qtnPCY5UWyoLa2rZVs8O1tdy24VhuPcmGPKtb3oQDFcfGKeNJrv7MPxh4WOC94+Z/dLM3jCzLWFb3Wnev832j5l9x4Jh+g/DYd3f0np/fBTzvCHO66Z+7A1c3eK9HNxUWxy9gX9psfyJBD+0xXuvnxGccrgc+MDM5prZdxO0LdKKAlRSysyOJQiHF1rOC4/Arnb3Q4ExwC/MbFjT7ARN7ukI9eCY54cQHOVuBj4DimPqygf2b0e7tQRfyLFtN9L8yz4Zm8OaWrZVk+T67b1d0gbgPXcvjXmUuPvoNtbZ3Ydm1o1g9KA2PN/5K2AssJ+7lwJbAGujvjuBNcDh7v4NgvA2otkA/KbFeyl2978l2PYGghGJ2OX3dfdbEtXr7vPdfThByK4hOFoXSYoCVFLCzL5hZmcADxCcW3wtzjJnmNm3zcwIvoh3EQyhQRBMh0bY9HlmdoSZFQNTgIfDYc23CI7K/snMCoBJBMOPTT4CKizxlZh/A35uZn3CUPkt8GA49Je0sJZZwG/MrCS8QOcXQLK/x/kR0MPCC5iS8DKw1cyuMbMiM8s3swHhDzaJjDazE8OLd24iOJ+6geCcbSOwCehiZpMJzl22pYTgvOK28GhufJJ1x3MPcLmZfc8C+4b7sySc3/IzMxP4oZmNCN93oQUXk/WK17iZHWhmZ1pwsdYOYBtffR5F9kgBKh31uJltJfjp/1rgj8CFCZY9HHia4ItqMXCHuy8M590MTAqH3n7Zju3fT3AhzIdAIXAVBFcFA1cAfyY42vsMiL0q96Hw3zozWxan3elh288B7xFctHNlO+qKdWW4/XcJjsz/Gra/R+6+hiDM3w37JtHwZdPyu4AzgGPCujcT9EFbAfxX4HqCodvBBOcSAeYDTxL8MPI+QR/saUj9l8C5BBcm3QM8uIflE3L3KuAS4E/AJwTD/xfELNLsMxOG/pkER72bwlorSfw9l0fww0wtwXs/mY4FvnzNNF0BKSJfQxb86ky1u0/KdC0iuUZHoCIiIhEoQEVERCLQEK6IiEgEOgIVERGJQAEqIiISQbvunlBWVuYVFRWdVIqIiEh2Wbp06WZ33z/evHYFaEVFBVVVVampSkREJMuZ2fuJ5mkIV0REJAIFqIiISAQKUBERkQjadQ5URERyy86dO6murmb79u2ZLiWrFRYW0qtXLwoKCpJeRwEqIrIXq66upqSkhIqKCoIbIUlL7k5dXR3V1dX06dMn6fU0hCsishfbvn07PXr0UHi2wczo0aNHu4/SFaAiIns5heeeRekjBaiIiHSa+vp67rjjjnavN3r0aOrr69tcZvLkyTz99NMRK+s4BaiIiHSaRAHa2NjY5nrz5s2jtLS0zWWmTJnCaaed1pHyOkQBKiIiu81eXsMJtzxLnwlzOeGWZ5m9vKZD7U2YMIF33nmHY445hmOPPZaTTjqJMWPGcMQRRwBw1llnMXjwYPr378/dd9+9e72Kigo2b97MunXr6NevH5dccgn9+/fn9NNPp6GhAYALLriAhx9+ePfy119/PYMGDeLII49kzZo1AGzatInhw4fTv39/Lr74Ynr37s3mzZs79J6aKEBFRAQIwnPio69RU9+AAzX1DUx89LUOhegtt9zCYYcdxooVK5g6dSrLli3jtttu46233gJg+vTpLF26lKqqKm6//Xbq6upatbF27Vp++tOfsnr1akpLS3nkkUfibqusrIxly5Yxfvx4fv/73wNw44038oMf/IDVq1dz9tlns379+sjvpSUFqIiIADB1/ps07NzVbFrDzl1Mnf9myrZx3HHHNftVkdtvv52jjz6aoUOHsmHDBtauXdtqnT59+nDMMccAMHjwYNatWxe37R//+MetlnnhhRcYN24cACNHjmS//fZL2XvR74GKiAgAtfUN7Zoexb777rv7+aJFi3j66adZvHgxxcXFnHLKKXF/lWSfffbZ/Tw/P3/3EG6i5fLz8/d4jjUVdAQqIiIAlJcWtWt6MkpKSti6dWvceVu2bGG//fajuLiYNWvWsGTJksjbSeSEE05g1qxZACxYsIBPPvkkZW0rQEVEBIDKEX0pKshvNq2oIJ/KEX0jt9mjRw9OOOEEBgwYQGVlZbN5I0eOpLGxkX79+jFhwgSGDh0aeTuJXH/99SxYsIABAwbw0EMPcdBBB1FSUpKSts3dk154yJAhrvuBiojkjjfeeIN+/folvfzs5TVMnf8mtfUNlJcWUTmiL2cN7NmJFXauHTt2kJ+fT5cuXVi8eDHjx49nxYoVcZeN11dmttTdh8RbXudARURkt7MG9szpwGxp/fr1jB07li+//JKuXbtyzz33pKxtBaiIiOy1Dj/8cJYvX94pbescqIiISAQKUBERkQgUoCIiIhEoQEVERCJQgIqISKeJejszgFtvvZXPP/989+tkbnGWTgpQERHpNKkM0GRucZZO+jUWERH5yquz4JkpsKUauveCYZPhqLGRm4u9ndnw4cM54IADmDVrFjt27OBHP/oRN954I5999hljx46lurqaXbt2cd111/HRRx9RW1vLqaeeSllZGQsXLqSiooKqqiq2bdvGqFGjOPHEE3nxxRfp2bMnjz32GEVFRbzyyitcdNFF5OXlMXz4cJ544glWrVqVwg76io5ARUQk8OosePwq2LIB8ODfx68KpkcUezuz4cOHs3btWl5++WVWrFjB0qVLee6553jyyScpLy9n5cqVrFq1ipEjR3LVVVdRXl7OwoULWbhwYat2E93i7MILL2TatGmsWLGC/Pz8VuulkgJUREQCz0yBnS3udLKzIZieAgsWLGDBggUMHDiQQYMGsWbNGtauXcuRRx7JU089xTXXXMPzzz9P9+7d99hWvFuc1dfXs3XrVo4//ngAzj333JTUnYiGcEVEJLClun3T28ndmThxIpdddlmrecuWLWPevHlMmjSJYcOGMXny5DbbSvYWZ51JR6AiIhLo3qt905MQezuzESNGMH36dLZt2wZATU0NGzdupLa2luLiYs477zwqKytZtmxZq3WTUVpaSklJCS+99BIADzzwQOS6k6EjUBERCQybHJzzjB3GLSgKpkcUezuzUaNGce655+4eYu3WrRszZ87k7bffprKykry8PAoKCrjzzjsBuPTSSxk5cuTuc6HJuPfee7nkkkvIy8vj5JNPTmo4OCrdzkxEZC/W3tuZpfoq3HTbtm0b3bp1A4ILmD744ANuu+22pNbV7cxERCS6o8bmVGC2NHfuXG6++WYaGxvp3bs3M2bM6LRtKUBFRGSvcc4553DOOeekZVu6iEhERCQCBaiIyF6uPde6fF1F6SMFqIjIXqywsJC6ujqFaBvcnbq6OgoLC9u1ns6BiojsxXr16kV1dTWbNm3KdClZrbCwkF692vf7rgpQEZG9WEFBAX369Ml0GXslDeGKiIhEoAAVERGJQAEqIiISgQJUREQkAgWoiIhIBApQERGRCBSgIiIiEShARUREIlCAioiIRKAAFRERiUABKiIiEkFG/hbu7OU1TJ3/JrX1DZSXFlE5oi9nDeyZiVISSnmNr86CZ6bAlmro3guGTe7QXd9zqQ+HfPoUE7s+xIFsxlLw3lNdXzb3YbabvbyGFXPv5uIvZlKeV8f2ooMoHjUlK/Zvk1zYz6/MmcbBy6ZygG9io+3PhkGVHDvmskyXtZv6ML60B+js5TVMfPQ1GnbuAqCmvoGJj74GkDU7JOU1vjoLHr8KdjYEr7dsCF5DpC+aXOrD4bv+zs0Ff6aYL4IZHXzvqa4vm/sw281eXsML/3sHU+xuivOC/Vvc8AGNj10ZfLFkQYjmwn5+Zc40BiydRJF9AQYHsYnuSyfxCmRFiKoPE0v7EO7U+W/u3hFNGnbuYur8N9NdSkIpr/GZKV+FZ5OdDcH0bKivEzTV+Ksusyi2L5rP7MB7T5Vc6MNsN3X+m/yMB1rt3y67tmd8/zbJhf188LKpwRd/jCL7goOXTc1QRc2pDxNLe4DW1je0a3ompLzGLdXtm74HudSH5bY5/gIR33uq5EIfZrva+oas3b9NcmE/H+Dx79N5gCfo2zRTHyaW9gAtLy1q1/RMSHmN3RPcpDXR9D3IpT6s9bL4C0R876mSC32Y7cpLi7J2/zbJhf280fZPMD1B36aZ+jCxtAdo5Yi+FBXkN5tWVJBP5Yi+6S4loZTXOGwyFLT4sBUUBdOzob5O0FTj7xrH8rl3bT6zA+89VXKhD7Nd5Yi+3Mq4Vvu3Mb8w4/u3SS7s5w2DKmlo0YcN3pUNgyozVFFz6sPE0n4RUdNJ52y+oivlNTZdTJGiq3Bzqw+7MvFTsu4q3Fzow2wX9NUV/G5ul6y9CjcX9vOxYy7jFQivIN3MRitjw+DsuQpXfZiYuXvSCw8ZMsSrqqo6sRwREZHsYWZL3X1IvHn6QwoiIiIRKEBFREQiUICKiIhEoAAVERGJQAEqIiISgQJUREQkAgWoiIhIBApQERGRCBSgIiIiEShARUREIlCAioiIRKAAFRERiUABKiIiEoECVEREJAIFqIiISAQKUBERkQgUoCIiIhEoQEVERCJQgIqIiESgABUREYlAASoiIhKBAlRERCQCBaiIiEgEClAREZEIFKAiIiIRKEBFREQiUICKiIhEoAAVERGJQAEqIiISgQJUREQkAgWoiIhIBApQERGRCBSgIiIiEShARUREIlCAioiIRKAAFRERiUABKiIiEoECVEREJAIFqIiISAQKUBERkQgUoCIiIhEoQEVERCJQgIqIiESgABUREYlAASoiIhKBAlRERCQCBaiIiEgEClAREZEIFKAiIiIRKEBFREQiMHdPfmGzTcD7Kdx+GbA5he19HakPO0592HHqw9RQP3Zcqvuwt7vvH29GuwI01cysyt2HZKyAvYD6sOPUhx2nPkwN9WPHpbMPNYQrIiISgQJUREQkgkwH6N0Z3v7eQH3YcerDjlMfpob6sePS1ocZPQcqIiKSqzJ9BCoiIpKT0hKgZjbSzN40s7fNbEKc+fuY2YPh/JfMrCIddeWSJPrwF2b2upm9ambPmFnvTNSZzfbUhzHL/bOZuZnpasgWkulDMxsbfhZXm9lf011jtkvi//IhZrbQzJaH/59HZ6LObGZm081so5mtSjDfzOz2sI9fNbNBnVKIu3fqA8gH3gEOBboCK4EjWixzBXBX+Hwc8GBn15VLjyT78FSgOHw+Xn3Y/j4MlysBngOWAEMyXXc2PZL8HB4OLAf2C18fkOm6s+mRZB/eDYwPnx8BrMt03dn2AL4PDAJWJZg/GngCMGAo8FJn1JGOI9DjgLfd/V13/wJ4ADizxTJnAn8Jnz8MDDMzS0NtuWKPfejuC9398/DlEqBXmmvMdsl8DgFuAv4b2J7O4nJEMn14CfA/7v4JgLtvTHON2S6ZPnTgG+Hz7kBtGuvLCe7+HPBxG4ucCdzngSVAqZl9K9V1pCNAewIbYl5Xh9PiLuPujcAWoEcaassVyfRhrIsIfvqSr+yxD8NhnoPdfW46C8shyXwOvwN8x8z+YWZLzGxk2qrLDcn04Q3AeWZWDcwDrkxPaXuV9n5nRtIl1Q1KZpnZecAQ4ORM15JLzCwP+CNwQYZLyXVdCIZxTyEYBXnOzI509/pMFpVj/hWY4e5/MLPjgfvNbIC7f5npwqS5dByB1gAHx7zuFU6Lu4yZdSEYtqhLQ225Ipk+xMxOA64Fxrj7jjTVliv21IclwABgkZmtIzhvMkcXEjWTzOewGpjj7jvd/T3gLYJAlUAyfXgRMAvA3RcDhQR/31WSl9R3ZkelI0BfAQ43sz5m1pXgIqE5LZaZA5wfPj8beNbDM8ECJNGHZjYQmEYQnjrv1FqbfejuW9y9zN0r3L2C4DzyGHevyky5WSmZ/8uzCY4+MbMygiHdd9NYY7ZLpg/XA8MAzKwfQYBuSmuVuW8O8O/h1bhDgS3u/kGqN9LpQ7ju3mhm/wnMJ7gCbbq7rzazKUCVu88B7iUYpnib4MTwuM6uK5ck2YdTgW7AQ+H1V+vdfUzGis4ySfahtCHJPpwPnG5mrwO7gEp312hSKMk+vBq4x8x+TnBB0QU6oGjOzP5G8INaWXiu+HqgAMDd7yI4dzwaeBv4HLiwU+rQfhEREWk//SUiERGRCBSgIiIiEShARUREIlCAioiIRKAAFRERiUABKiIiEoECVEREJAIFqEgWM7NFZvbd8HmPRPc/FJH0U4CKZLdvE/w9WYCjgNcyWIuIxFCAimQpM+sN1MTcheMo4NUMliQiMRSgItnraJoH5mAUoCJZQwEqkr2OIbgTB2Z2OHAmGsIVyRoKUJHsdTSQZ2YrgcnA63x12z8RyTDdjUUkS5nZWmCQu2/NdC0i0pqOQEWykJmVAK7wFMleOgIVERGJQEegIiIiEShARUREIlCAioiIRKAAFRERiUABKiIiEoECVEREJAIFqIiISAQKUBERkQj+HwmloAfUF9DfAAAAAElFTkSuQmCC\n",
@@ -254,10 +247,9 @@
     "N_nonpredict = 40\n",
     "\n",
     "t2 = np.array([4*np.pi + i*step for i in range(-N_nonpredict+1,N_predict+1)])\n",
-    "print(t2.shape)\n",
     "xgrid2, tgrid2 = np.meshgrid(x, t2)\n",
     "\n",
-    "testing_snapshots = np.array([f(p)(xgrid2, tgrid2) for p in testing_params])\n",
+    "testing_snapshots = np.array([f(p)(xgrid2, tgrid2).T for p in testing_params])\n",
     "\n",
     "plt.figure(figsize=(8,2))\n",
     "plt.scatter(training_params, np.zeros(len(training_params)), label='training')\n",
@@ -307,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "capable-referral",
    "metadata": {},
    "outputs": [],
@@ -326,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 23,
    "id": "according-argentina",
    "metadata": {},
    "outputs": [
@@ -351,17 +343,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 24,
    "id": "transsexual-mason",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(5, 80, 500)"
+       "(5, 500, 80)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -381,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 28,
    "id": "alike-turkish",
    "metadata": {},
    "outputs": [
@@ -473,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 29,
    "id": "random-snapshot",
    "metadata": {},
    "outputs": [
@@ -513,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 30,
    "id": "convertible-simpson",
    "metadata": {},
    "outputs": [],
@@ -534,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 31,
    "id": "bored-oliver",
    "metadata": {},
    "outputs": [],
@@ -555,17 +547,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 32,
    "id": "chicken-belarus",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(5, 80, 500)"
+       "(5, 500, 80)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -585,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 33,
    "id": "premium-heater",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
In this commit I addressed the problem remarked in #274. I adjusted accordingly the tests in `test_paramdmd` and `tutorial10`. I also cleaned the code a little bit, and improved the performance replacing some calls to `np.split` with `reshape` when possible.

Closes #274