### PR TITLE
Complete transition to `pytest`

### DIFF
--- a/tests/test_cdmd.py
+++ b/tests/test_cdmd.py
@@ -1,5 +1,4 @@
 from builtins import range
-from unittest import TestCase
 from pytest import raises
 from pydmd.cdmd import CDMD
 import matplotlib.pyplot as plt
@@ -33,342 +32,341 @@ def create_noisy_data():
 noisy_data = create_noisy_data()
 
 
-class TestCDmd(TestCase):
-    def test_shape(self):
-        dmd = CDMD(svd_rank=-1)
-        dmd.fit(X=[d for d in sample_data.T])
-        assert dmd.modes.shape[1] == sample_data.shape[1] - 1
+def test_shape():
+    dmd = CDMD(svd_rank=-1)
+    dmd.fit(X=[d for d in sample_data.T])
+    assert dmd.modes.shape[1] == sample_data.shape[1] - 1
 
-    def test_truncation_shape(self):
-        dmd = CDMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == 3
+def test_truncation_shape():
+    dmd = CDMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == 3
 
-    def test_Atilde_shape(self):
-        dmd = CDMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
+def test_Atilde_shape():
+    dmd = CDMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
 
-    def test_eigs_1(self):
-        dmd = CDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 14
+def test_eigs_1():
+    dmd = CDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 14
 
-    def test_eigs_2(self):
-        dmd = CDMD(svd_rank=5)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 5
+def test_eigs_2():
+    dmd = CDMD(svd_rank=5)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 5
 
-    def test_eigs_3(self):
-        dmd = CDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_eigs = np.array(
-            [-0.47386866 + 0.88059553j, -0.80901699 + 0.58778525j])
-        np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
+def test_eigs_3():
+    dmd = CDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_eigs = np.array(
+        [-0.47386866 + 0.88059553j, -0.80901699 + 0.58778525j])
+    np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
 
-    def test_dynamics_1(self):
-        dmd = CDMD(svd_rank=5)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
+def test_dynamics_1():
+    dmd = CDMD(svd_rank=5)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
 
-    def test_reconstructed_data(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        dmd_data = dmd.reconstructed_data
-        np.testing.assert_allclose(dmd_data, sample_data)
+def test_reconstructed_data():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    dmd_data = dmd.reconstructed_data
+    np.testing.assert_allclose(dmd_data, sample_data)
 
-    def test_original_time(self):
-        dmd = CDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
-        np.testing.assert_equal(dmd.original_time, expected_dict)
+def test_original_time():
+    dmd = CDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+    np.testing.assert_equal(dmd.original_time, expected_dict)
 
-    def test_original_timesteps(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        np.testing.assert_allclose(dmd.original_timesteps,
-                                   np.arange(sample_data.shape[1]))
+def test_original_timesteps():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    np.testing.assert_allclose(dmd.original_timesteps,
+                                np.arange(sample_data.shape[1]))
 
-    def test_dmd_time_1(self):
-        dmd = CDMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
-        np.testing.assert_equal(dmd.dmd_time, expected_dict)
+def test_dmd_time_1():
+    dmd = CDMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+    np.testing.assert_equal(dmd.dmd_time, expected_dict)
 
-    def test_dmd_time_2(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 10
-        dmd.dmd_time['tend'] = 14
-        expected_data = sample_data[:, -5:]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+def test_dmd_time_2():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 10
+    dmd.dmd_time['tend'] = 14
+    expected_data = sample_data[:, -5:]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
-    def test_dmd_time_3(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 8
-        dmd.dmd_time['tend'] = 11
-        expected_data = sample_data[:, 8:12]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+def test_dmd_time_3():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 8
+    dmd.dmd_time['tend'] = 11
+    expected_data = sample_data[:, 8:12]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
-    def test_plot_eigs_1(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=True, show_unit_circle=True)
-        plt.close()
+def test_plot_eigs_1():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=True, show_unit_circle=True)
+    plt.close()
 
-    def test_plot_eigs_2(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_eigs_2():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
 
-    def test_plot_modes_1(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_modes_2D()
-
-    def test_plot_modes_2(self):
-        dmd = CDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
-
-    def test_plot_modes_3(self):
-        dmd = CDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
+def test_plot_modes_1():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
         dmd.plot_modes_2D()
-        plt.close()
 
-    def test_plot_modes_4(self):
-        dmd = CDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1)
-        plt.close()
+def test_plot_modes_2():
+    dmd = CDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
 
-    def test_plot_modes_5(self):
-        dmd = CDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.1.png')
+def test_plot_modes_3():
+    dmd = CDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D()
+    plt.close()
 
-    def test_plot_snapshots_1(self):
-        dmd = CDMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_snapshots_2D()
+def test_plot_modes_4():
+    dmd = CDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1)
+    plt.close()
 
-    def test_plot_snapshots_2(self):
-        dmd = CDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
+def test_plot_modes_5():
+    dmd = CDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
+    os.remove('tmp.1.png')
 
-    def test_plot_snapshots_3(self):
-        dmd = CDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
+def test_plot_snapshots_1():
+    dmd = CDMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
         dmd.plot_snapshots_2D()
-        plt.close()
 
-    def test_plot_snapshots_4(self):
-        dmd = CDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2)
-        plt.close()
+def test_plot_snapshots_2():
+    dmd = CDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
 
-    def test_plot_snapshots_5(self):
-        dmd = CDMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.2.png')
+def test_plot_snapshots_3():
+    dmd = CDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D()
+    plt.close()
 
-    def test_tdmd_plot(self):
-        dmd = CDMD(tlsq_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_snapshots_4():
+    dmd = CDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2)
+    plt.close()
 
-    def test_cdmd_matrix_uniform(self):
-        dmd = CDMD(compression_matrix='uniform')
-        dmd.fit(X=sample_data)
-        error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
-        assert error_norm < 1e-10
+def test_plot_snapshots_5():
+    dmd = CDMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
+    os.remove('tmp.2.png')
 
-    def test_cdmd_matrix_sample(self):
-        dmd = CDMD(compression_matrix='sample')
-        dmd.fit(X=sample_data)
-        error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
-        assert error_norm < 1e-10
+def test_tdmd_plot():
+    dmd = CDMD(tlsq_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
 
-    def test_cdmd_matrix_normal(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
-        error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
-        assert error_norm < 1e-10
+def test_cdmd_matrix_uniform():
+    dmd = CDMD(compression_matrix='uniform')
+    dmd.fit(X=sample_data)
+    error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
+    assert error_norm < 1e-10
 
-    def test_cdmd_matrix_sparse(self):
-        dmd = CDMD(compression_matrix='sparse')
-        dmd.fit(X=sample_data)
-        error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
-        assert error_norm < 1e-10
+def test_cdmd_matrix_sample():
+    dmd = CDMD(compression_matrix='sample')
+    dmd.fit(X=sample_data)
+    error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
+    assert error_norm < 1e-10
 
-    def test_cdmd_matrix_custom(self):
-        matrix = np.random.permutation(
-            (sample_data.shape[1] - 3) * sample_data.shape[0]).reshape(
-                sample_data.shape[1] - 3, sample_data.shape[0]).astype(float)
-        matrix /= float(np.sum(matrix))
-        dmd = CDMD(compression_matrix=matrix)
-        dmd.fit(X=sample_data)
-        error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
-        assert error_norm < 1e-10
+def test_cdmd_matrix_normal():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
+    error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
+    assert error_norm < 1e-10
 
-    def test_sorted_eigs_default(self):
-        dmd = CDMD(compression_matrix='sparse')
-        assert dmd.operator._sorted_eigs == False
+def test_cdmd_matrix_sparse():
+    dmd = CDMD(compression_matrix='sparse')
+    dmd.fit(X=sample_data)
+    error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
+    assert error_norm < 1e-10
 
-    def test_sorted_eigs_param(self):
-        dmd = CDMD(compression_matrix='sparse', sorted_eigs='real')
-        assert dmd.operator._sorted_eigs == 'real'
+def test_cdmd_matrix_custom():
+    matrix = np.random.permutation(
+        (sample_data.shape[1] - 3) * sample_data.shape[0]).reshape(
+            sample_data.shape[1] - 3, sample_data.shape[0]).astype(float)
+    matrix /= float(np.sum(matrix))
+    dmd = CDMD(compression_matrix=matrix)
+    dmd.fit(X=sample_data)
+    error_norm = np.linalg.norm(dmd.reconstructed_data - sample_data, 1)
+    assert error_norm < 1e-10
 
-    def test_get_bitmask_default(self):
-        dmd = CDMD(compression_matrix='normal',)
-        dmd.fit(X=sample_data)
-        assert np.all(dmd.modes_activation_bitmask == True)
+def test_sorted_eigs_default():
+    dmd = CDMD(compression_matrix='sparse')
+    assert dmd.operator._sorted_eigs == False
 
-    def test_set_bitmask(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
+def test_sorted_eigs_param():
+    dmd = CDMD(compression_matrix='sparse', sorted_eigs='real')
+    assert dmd.operator._sorted_eigs == 'real'
 
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_get_bitmask_default():
+    dmd = CDMD(compression_matrix='normal',)
+    dmd.fit(X=sample_data)
+    assert np.all(dmd.modes_activation_bitmask == True)
 
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
+def test_set_bitmask():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
 
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = CDMD(compression_matrix='normal')
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = CDMD(compression_matrix='normal')
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
 
-    def test_raise_wrong_dtype_bitmask(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
+def test_not_fitted_get_bitmask_raises():
+    dmd = CDMD(compression_matrix='normal')
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
 
-    def test_fitted(self):
-        dmd = CDMD(compression_matrix='normal')
-        assert not dmd.fitted
-        dmd.fit(X=sample_data)
-        assert dmd.fitted
+def test_not_fitted_set_bitmask_raises():
+    dmd = CDMD(compression_matrix='normal')
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
 
-    def test_bitmask_amplitudes(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
+def test_raise_wrong_dtype_bitmask():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
 
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+def test_fitted():
+    dmd = CDMD(compression_matrix='normal')
+    assert not dmd.fitted
+    dmd.fit(X=sample_data)
+    assert dmd.fitted
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_bitmask_amplitudes():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
 
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
 
-    def test_bitmask_eigs(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_bitmask_eigs():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
 
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
 
-    def test_bitmask_modes(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_bitmask_modes():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
 
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
 
-    def test_getitem_modes(self):
-        dmd = CDMD(compression_matrix='normal', svd_rank=10)
-        dmd.fit(X=sample_data)
-        old_n_modes = dmd.modes.shape[1]
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-        assert dmd.modes.shape[1] == old_n_modes
+def test_getitem_modes():
+    dmd = CDMD(compression_matrix='normal', svd_rank=10)
+    dmd.fit(X=sample_data)
+    old_n_modes = dmd.modes.shape[1]
 
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[[1,3]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[2].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+    assert dmd[[1,3]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-    def test_getitem_raises(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
+    assert dmd[2].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
 
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
+    assert dmd.modes.shape[1] == old_n_modes
 
-    def test_reconstructed_data(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
+def test_getitem_raises():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
 
-        dmd.reconstructed_data
-        assert True
+def test_reconstructed_data():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
 
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        dmd = CDMD(compression_matrix='normal')
-        dmd.fit(X=sample_data)
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    dmd.reconstructed_data
+    assert True
+
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    dmd = CDMD(compression_matrix='normal')
+    dmd.fit(X=sample_data)
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -1,9 +1,9 @@
 from builtins import range
-from unittest import TestCase
 from pydmd.dmd import DMD
 import matplotlib.pyplot as plt
 import numpy as np
 import os
+from pytest import raises
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -32,667 +32,666 @@ def create_noisy_data():
 noisy_data = create_noisy_data()
 
 
-class TestDmd(TestCase):
-    def test_shape(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == sample_data.shape[1] - 1
+def test_shape():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == sample_data.shape[1] - 1
 
-    def test_truncation_shape(self):
-        dmd = DMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == 3
+def test_truncation_shape():
+    dmd = DMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == 3
 
-    def test_rank(self):
-        dmd = DMD(svd_rank=0.9)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 2
+def test_rank():
+    dmd = DMD(svd_rank=0.9)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 2
 
-    def test_Atilde_shape(self):
-        dmd = DMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
+def test_Atilde_shape():
+    dmd = DMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    assert dmd.atilde.shape == (dmd.svd_rank, dmd.svd_rank)
 
-    def test_Atilde_values(self):
-        dmd = DMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        exact_atilde = np.array(
-            [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
-             [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
-        np.testing.assert_allclose(exact_atilde, dmd.atilde)
+def test_Atilde_values():
+    dmd = DMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    exact_atilde = np.array(
+        [[-0.70558526 + 0.67815084j, 0.22914898 + 0.20020143j],
+            [0.10459069 + 0.09137814j, -0.57730040 + 0.79022994j]])
+    np.testing.assert_allclose(exact_atilde, dmd.atilde)
 
-    def test_eigs_1(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 14
+def test_eigs_1():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 14
 
-    def test_eigs_2(self):
-        dmd = DMD(svd_rank=5)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 5
+def test_eigs_2():
+    dmd = DMD(svd_rank=5)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 5
 
-    def test_eigs_3(self):
-        dmd = DMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_eigs = np.array([
-            -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
-        ])
-        np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
+def test_eigs_3():
+    dmd = DMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_eigs = np.array([
+        -8.09016994e-01 + 5.87785252e-01j, -4.73868662e-01 + 8.80595532e-01j
+    ])
+    np.testing.assert_almost_equal(dmd.eigs, expected_eigs, decimal=6)
 
-    def test_dynamics_1(self):
-        dmd = DMD(svd_rank=5)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
+def test_dynamics_1():
+    dmd = DMD(svd_rank=5)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
 
-    def test_dynamics_2(self):
-        dmd = DMD(svd_rank=1)
-        dmd.fit(X=sample_data)
-        expected_dynamics = np.array([[
-            -2.20639502 - 9.10168802e-16j, 1.55679980 - 1.49626864e+00j,
-            -0.08375915 + 2.11149018e+00j, -1.37280962 - 1.54663768e+00j,
-            2.01748787 + 1.60312745e-01j, -1.53222592 + 1.25504678e+00j,
-            0.23000498 - 1.92462280e+00j, 1.14289644 + 1.51396355e+00j,
-            -1.83310653 - 2.93174173e-01j, 1.49222925 - 1.03626336e+00j,
-            -0.35015209 + 1.74312867e+00j, -0.93504202 - 1.46738182e+00j,
-            1.65485808 + 4.01263449e-01j, -1.43976061 + 8.39117825e-01j,
-            0.44682540 - 1.56844403e+00j
-        ]])
-        np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
+def test_dynamics_2():
+    dmd = DMD(svd_rank=1)
+    dmd.fit(X=sample_data)
+    expected_dynamics = np.array([[
+        -2.20639502 - 9.10168802e-16j, 1.55679980 - 1.49626864e+00j,
+        -0.08375915 + 2.11149018e+00j, -1.37280962 - 1.54663768e+00j,
+        2.01748787 + 1.60312745e-01j, -1.53222592 + 1.25504678e+00j,
+        0.23000498 - 1.92462280e+00j, 1.14289644 + 1.51396355e+00j,
+        -1.83310653 - 2.93174173e-01j, 1.49222925 - 1.03626336e+00j,
+        -0.35015209 + 1.74312867e+00j, -0.93504202 - 1.46738182e+00j,
+        1.65485808 + 4.01263449e-01j, -1.43976061 + 8.39117825e-01j,
+        0.44682540 - 1.56844403e+00j
+    ]])
+    np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
 
-    def test_dynamics_opt_1(self):
-        dmd = DMD(svd_rank=5, opt=True)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (5, sample_data.shape[1])
+def test_dynamics_opt_1():
+    dmd = DMD(svd_rank=5, opt=True)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (5, sample_data.shape[1])
 
-    def test_dynamics_opt_2(self):
-        dmd = DMD(svd_rank=1, opt=True)
-        dmd.fit(X=sample_data)
-        expected_dynamics = np.array([[
-            -4.609718826226513-6.344781724790875j,
-            7.5552686987577165+1.3506997434096375j,
-            -6.246864367654589+4.170577993207872j,
-            1.5794144248628537-7.179014663490048j,
-            3.754043295828462+6.13648812118528j,
-            -6.810262177959786-1.7840079278093528j,
-            6.015047060133346-3.35961532862783j,
-            -1.9658025630719695+6.449604262000736j,
-            -2.9867632454837936-5.8838563367460734j,
-            6.097558230017521+2.126086276430128j,
-            -5.7441543819530265+2.6349291080417103j,
-            2.266111252852836-5.7545702519088895j,
-            2.303531963541068+5.597105176945707j,
-            -5.421019770795679-2.3870927539102658j,
-            5.443800581850978-1.9919716610066682j,
-        ]])
-        np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
+def test_dynamics_opt_2():
+    dmd = DMD(svd_rank=1, opt=True)
+    dmd.fit(X=sample_data)
+    expected_dynamics = np.array([[
+        -4.609718826226513-6.344781724790875j,
+        7.5552686987577165+1.3506997434096375j,
+        -6.246864367654589+4.170577993207872j,
+        1.5794144248628537-7.179014663490048j,
+        3.754043295828462+6.13648812118528j,
+        -6.810262177959786-1.7840079278093528j,
+        6.015047060133346-3.35961532862783j,
+        -1.9658025630719695+6.449604262000736j,
+        -2.9867632454837936-5.8838563367460734j,
+        6.097558230017521+2.126086276430128j,
+        -5.7441543819530265+2.6349291080417103j,
+        2.266111252852836-5.7545702519088895j,
+        2.303531963541068+5.597105176945707j,
+        -5.421019770795679-2.3870927539102658j,
+        5.443800581850978-1.9919716610066682j,
+    ]])
+    np.testing.assert_allclose(dmd.dynamics, expected_dynamics)
 
-    def test_reconstructed_data(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        dmd_data = dmd.reconstructed_data
-        np.testing.assert_allclose(dmd_data, sample_data)
+def test_reconstructed_data():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    dmd_data = dmd.reconstructed_data
+    np.testing.assert_allclose(dmd_data, sample_data)
 
-    def test_original_time(self):
-        dmd = DMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
-        np.testing.assert_equal(dmd.original_time, expected_dict)
+def test_original_time():
+    dmd = DMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+    np.testing.assert_equal(dmd.original_time, expected_dict)
 
-    def test_original_timesteps(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        np.testing.assert_allclose(dmd.original_timesteps,
-                                   np.arange(sample_data.shape[1]))
+def test_original_timesteps():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    np.testing.assert_allclose(dmd.original_timesteps,
+                                np.arange(sample_data.shape[1]))
 
-    def test_dmd_time_1(self):
-        dmd = DMD(svd_rank=2)
-        dmd.fit(X=sample_data)
-        expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
-        np.testing.assert_equal(dmd.dmd_time, expected_dict)
+def test_dmd_time_1():
+    dmd = DMD(svd_rank=2)
+    dmd.fit(X=sample_data)
+    expected_dict = {'dt': 1, 't0': 0, 'tend': 14}
+    np.testing.assert_equal(dmd.dmd_time, expected_dict)
 
-    def test_dmd_time_2(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 10
-        dmd.dmd_time['tend'] = 14
-        expected_data = sample_data[:, -5:]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+def test_dmd_time_2():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 10
+    dmd.dmd_time['tend'] = 14
+    expected_data = sample_data[:, -5:]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
-    def test_dmd_time_3(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 8
-        dmd.dmd_time['tend'] = 11
-        expected_data = sample_data[:, 8:12]
-        np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
+def test_dmd_time_3():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 8
+    dmd.dmd_time['tend'] = 11
+    expected_data = sample_data[:, 8:12]
+    np.testing.assert_allclose(dmd.reconstructed_data, expected_data)
 
-    def test_dmd_time_4(self):
-        dmd = DMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.dmd_time['t0'] = 20
-        dmd.dmd_time['tend'] = 20
-        expected_data = np.array([[-7.29383297e+00 - 4.90248179e-14j],
-                                  [-5.69109796e+00 - 2.74068833e+00j],
-                                  [3.38410649e-83 + 3.75677740e-83j]])
-        np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
+def test_dmd_time_4():
+    dmd = DMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.dmd_time['t0'] = 20
+    dmd.dmd_time['tend'] = 20
+    expected_data = np.array([[-7.29383297e+00 - 4.90248179e-14j],
+                                [-5.69109796e+00 - 2.74068833e+00j],
+                                [3.38410649e-83 + 3.75677740e-83j]])
+    np.testing.assert_almost_equal(dmd.dynamics, expected_data, decimal=6)
 
-    def test_plot_eigs_1(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=True, show_unit_circle=True)
-        plt.close()
+def test_plot_eigs_1():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=True, show_unit_circle=True)
+    plt.close()
 
-    def test_plot_eigs_2(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_eigs_2():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
 
-    def test_plot_eigs_3(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=True, filename='eigs.png')
-        self.addCleanup(os.remove, 'eigs.png')
+def test_plot_eigs_3():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=True, filename='eigs.png')
+    os.remove('eigs.png')
 
-    def test_plot_modes_1(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_modes_2D()
-
-    def test_plot_modes_2(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
-
-    def test_plot_modes_3(self):
-        dmd = DMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
+def test_plot_modes_1():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
         dmd.plot_modes_2D()
-        plt.close()
 
-    def test_plot_modes_4(self):
-        dmd = DMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1)
-        plt.close()
+def test_plot_modes_2():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_modes_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
 
-    def test_plot_modes_5(self):
-        dmd = DMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.1.png')
+def test_plot_modes_3():
+    dmd = DMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D()
+    plt.close()
 
-    def test_plot_snapshots_1(self):
-        dmd = DMD()
-        dmd.fit(X=sample_data)
-        with self.assertRaises(ValueError):
-            dmd.plot_snapshots_2D()
+def test_plot_modes_4():
+    dmd = DMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1)
+    plt.close()
 
-    def test_plot_snapshots_2(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
-        plt.close()
+def test_plot_modes_5():
+    dmd = DMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_modes_2D(index_mode=1, filename='tmp.png')
+    os.remove('tmp.1.png')
 
-    def test_plot_snapshots_3(self):
-        dmd = DMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
+def test_plot_snapshots_1():
+    dmd = DMD()
+    dmd.fit(X=sample_data)
+    with raises(ValueError):
         dmd.plot_snapshots_2D()
-        plt.close()
 
-    def test_plot_snapshots_4(self):
-        dmd = DMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2)
-        plt.close()
+def test_plot_snapshots_2():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_snapshots_2D((1, 2, 5), x=np.arange(20), y=np.arange(20))
+    plt.close()
 
-    def test_plot_snapshots_5(self):
-        dmd = DMD()
-        snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
-        dmd.fit(X=snapshots)
-        dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
-        self.addCleanup(os.remove, 'tmp.2.png')
+def test_plot_snapshots_3():
+    dmd = DMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D()
+    plt.close()
 
-    def test_tdmd_plot(self):
-        dmd = DMD(tlsq_rank=3)
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_snapshots_4():
+    dmd = DMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2)
+    plt.close()
 
-    # we check that modes are the same vector multiplied by a coefficient
-    # when we rescale
-    def test_rescale_mode_auto_same_modes(self):
-        dmd_no_rescale = DMD(svd_rank=2, opt=True, rescale_mode=None)
-        dmd_no_rescale.fit(X=sample_data)
+def test_plot_snapshots_5():
+    dmd = DMD()
+    snapshots = [snap.reshape(20, 20) for snap in sample_data.T]
+    dmd.fit(X=snapshots)
+    dmd.plot_snapshots_2D(index_snap=2, filename='tmp.png')
+    os.remove('tmp.2.png')
 
-        dmd_auto_rescale = DMD(svd_rank=2, opt=True, rescale_mode='auto')
-        dmd_auto_rescale.fit(X=sample_data)
+def test_tdmd_plot():
+    dmd = DMD(tlsq_rank=3)
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
 
-        def normalize(vector):
-            return vector / np.linalg.norm(vector)
+# we check that modes are the same vector multiplied by a coefficient
+# when we rescale
+def test_rescale_mode_auto_same_modes():
+    dmd_no_rescale = DMD(svd_rank=2, opt=True, rescale_mode=None)
+    dmd_no_rescale.fit(X=sample_data)
 
-        dmd_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
-            dmd_auto_rescale.modes)
-        dmd_no_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
-            dmd_no_rescale.modes)
+    dmd_auto_rescale = DMD(svd_rank=2, opt=True, rescale_mode='auto')
+    dmd_auto_rescale.fit(X=sample_data)
 
-        np.testing.assert_almost_equal(dmd_no_rescale_normalized_modes,
-            dmd_rescale_normalized_modes, decimal=3)
+    def normalize(vector):
+        return vector / np.linalg.norm(vector)
 
-    # we check that modes are the same vector multiplied by a coefficient
-    # when we rescale
-    def test_rescale_mode_custom_same_modes(self):
-        dmd_no_rescale = DMD(svd_rank=2, opt=True, rescale_mode=None)
-        dmd_no_rescale.fit(X=sample_data)
+    dmd_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
+        dmd_auto_rescale.modes)
+    dmd_no_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
+        dmd_no_rescale.modes)
 
-        dmd_rescale = DMD(svd_rank=2, opt=True, rescale_mode=
-            np.linspace(5,10, 2))
+    np.testing.assert_almost_equal(dmd_no_rescale_normalized_modes,
+        dmd_rescale_normalized_modes, decimal=3)
+
+# we check that modes are the same vector multiplied by a coefficient
+# when we rescale
+def test_rescale_mode_custom_same_modes():
+    dmd_no_rescale = DMD(svd_rank=2, opt=True, rescale_mode=None)
+    dmd_no_rescale.fit(X=sample_data)
+
+    dmd_rescale = DMD(svd_rank=2, opt=True, rescale_mode=
+        np.linspace(5,10, 2))
+    dmd_rescale.fit(X=sample_data)
+
+    def normalize(vector):
+        return vector / np.linalg.norm(vector)
+
+    dmd_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
+        dmd_rescale.modes)
+    dmd_no_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
+        dmd_no_rescale.modes)
+
+    np.testing.assert_almost_equal(dmd_no_rescale_normalized_modes,
+        dmd_rescale_normalized_modes, decimal=3)
+
+def test_rescale_mode_same_evolution():
+    dmd_no_rescale = DMD(svd_rank=5, opt=True, exact=True,
+                            rescale_mode=None)
+    dmd_no_rescale.fit(X=sample_data)
+    dmd_no_rescale.dmd_time['tend'] *= 2
+
+    dmd_rescale = DMD(svd_rank=5, opt=True, exact=True, rescale_mode=
+        np.linspace(5,10, 5))
+    dmd_rescale.fit(X=sample_data)
+    dmd_rescale.dmd_time['tend'] *= 2
+
+    np.testing.assert_almost_equal(dmd_rescale.reconstructed_data,
+        dmd_no_rescale.reconstructed_data, decimal=6)
+
+def test_rescale_mode_coefficients_count_check():
+    dmd_rescale = DMD(svd_rank=5, opt=True, rescale_mode=
+        np.linspace(5,10, 6))
+    with raises(ValueError):
         dmd_rescale.fit(X=sample_data)
 
-        def normalize(vector):
-            return vector / np.linalg.norm(vector)
-
-        dmd_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
-            dmd_rescale.modes)
-        dmd_no_rescale_normalized_modes = np.apply_along_axis(normalize, 0,
-            dmd_no_rescale.modes)
-
-        np.testing.assert_almost_equal(dmd_no_rescale_normalized_modes,
-            dmd_rescale_normalized_modes, decimal=3)
-
-    def test_rescale_mode_same_evolution(self):
-        dmd_no_rescale = DMD(svd_rank=5, opt=True, exact=True,
-                             rescale_mode=None)
-        dmd_no_rescale.fit(X=sample_data)
-        dmd_no_rescale.dmd_time['tend'] *= 2
-
-        dmd_rescale = DMD(svd_rank=5, opt=True, exact=True, rescale_mode=
-            np.linspace(5,10, 5))
-        dmd_rescale.fit(X=sample_data)
-        dmd_rescale.dmd_time['tend'] *= 2
-
-        np.testing.assert_almost_equal(dmd_rescale.reconstructed_data,
-            dmd_no_rescale.reconstructed_data, decimal=6)
-
-    def test_rescale_mode_coefficients_count_check(self):
-        dmd_rescale = DMD(svd_rank=5, opt=True, rescale_mode=
-            np.linspace(5,10, 6))
-        with self.assertRaises(ValueError):
-            dmd_rescale.fit(X=sample_data)
-
-    def test_predict(self):
-        def f1(x,t):
-            return 1./np.cosh(x+3)*np.exp(2.3j*t)
-
-        def f2(x,t):
-            return 2./np.cosh(x)*np.tanh(x)*np.exp(2.8j*t)
-
-        x = np.linspace(-2, 2, 4)
-        t = np.linspace(0, 4*np.pi, 10)
-
-        xgrid, tgrid = np.meshgrid(x, t)
-
-        X1 = f1(xgrid, tgrid)
-        X2 = f2(xgrid, tgrid)
-        X = X1 + X2
-
-        dmd = DMD()
-        dmd.fit(X.T)
-
-        expected = np.array([
-            [ 0.35407111+0.31966903j,  0.0581077 -0.51616519j,
-                -0.4936891 +0.36476117j,  0.70397844+0.05332291j,
-                -0.56648961-0.50687223j,  0.15372065+0.74444603j,
-                0.30751808-0.63550106j, -0.5633934 +0.24365451j,
-                0.47550633+0.20903766j, -0.0985528 -0.46673545j],
-            [ 0.52924739+0.47782492j,  0.08685642-0.77153733j,
-                -0.73794122+0.54522635j,  1.05227097+0.07970435j,
-                -0.8467597 -0.7576467j ,  0.22977376+1.11275987j,
-                0.4596623 -0.94991449j, -0.84213164+0.3642023j ,
-                0.71076254+0.3124588j , -0.14731169-0.69765229j],
-            [-0.49897731-0.45049592j, -0.0818887 +0.72740958j,
-                0.69573498-0.51404236j, -0.99208678-0.0751457j ,
-                0.79832963+0.71431342j, -0.21663195-1.04911604j,
-                -0.43337211+0.89558454j,  0.79396628-0.3433719j ,
-                -0.67011078-0.29458785j,  0.13888626+0.65775036j],
-            [-0.2717424 -0.2453395j , -0.04459648+0.39614632j,
-                0.37889637-0.2799468j , -0.54028918-0.04092425j,
-                0.43476929+0.38901417j, -0.11797748-0.57134724j,
-                -0.23601389+0.48773418j,  0.43239301-0.18699989j,
-                - 0.36494147 - 0.16043216j, 0.07563728 + 0.35821j]
-        ])
-
-        np.testing.assert_almost_equal(dmd.predict(X.T), expected, decimal=6)
-
-    def test_predict_exact(self):
-        dmd = DMD(exact=True)
-        expected = np.load('tests/test_datasets/input_sample_predict_exact.npy')
-
-        np.testing.assert_almost_equal(dmd
-            .fit(sample_data)
-            .predict(sample_data[:,20:40]), expected, decimal=6)
-
-    def test_predict_nexact(self):
-        dmd = DMD(exact=False)
-        expected = np.load('tests/test_datasets/input_sample_predict_nexact.npy')
-
-        np.testing.assert_almost_equal(dmd
-            .fit(sample_data)
-            .predict(sample_data[:, 10:30]), expected, decimal=6)
-
-
-    def test_advanced_snapshot_parameter(self):
-        dmd = DMD(svd_rank=0.99)
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=0.99, opt=-1)
-        dmd2.fit(sample_data)
-
-        np.testing.assert_almost_equal(dmd2.reconstructed_data.real,
-            dmd.reconstructed_data.real, decimal=6)
-
-
-    def test_sorted_eigs_default(self):
-        dmd = DMD()
-        assert dmd.operator._sorted_eigs == False
-
-    def test_sorted_eigs_set_real(self):
-        dmd = DMD(sorted_eigs='real')
-        assert dmd.operator._sorted_eigs == 'real'
-
-    def test_sorted_eigs_abs_right_eigs(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='abs')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        assert len(dmd.eigs) == len(dmd2.eigs)
-        assert set(dmd.eigs) == set(dmd2.eigs)
-
-        previous = dmd.eigs[0]
-        for eig in dmd.eigs[1:]:
-            assert abs(previous) <= abs(eig)
-            previous = eig
-
-    def test_sorted_eigs_abs_right_eigenvectors(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='abs')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            eigenvector = dmd2.operator.eigenvectors.T[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    assert all(dmd.operator.eigenvectors.T[idx_new] == eigenvector)
-                    break
-
-    def test_sorted_eigs_abs_right_modes(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='abs')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            mode = dmd2.modes.T[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    np.testing.assert_almost_equal(dmd.modes.T[idx_new], mode,
-                        decimal=6)
-                    break
-
-    def test_sorted_eigs_real_right_eigs(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='real')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        assert len(dmd.eigs) == len(dmd2.eigs)
-        assert set(dmd.eigs) == set(dmd2.eigs)
-
-        previous = complex(dmd.eigs[0])
-        for eig in dmd.eigs[1:]:
-            x = complex(eig)
-            assert x.real > previous.real or (x.real == previous.real and x.imag >= previous.imag)
-            previous = x
-
-    def test_sorted_eigs_real_right_eigenvectors(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='real')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            eigenvector = dmd2.operator.eigenvectors.T[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    assert all(dmd.operator.eigenvectors.T[idx_new] == eigenvector)
-                    break
-
-    def test_sorted_eigs_real_right_modes(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='real')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            mode = dmd2.modes.T[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    np.testing.assert_almost_equal(dmd.modes.T[idx_new], mode,
-                        decimal=6)
-                    break
-
-    def test_sorted_eigs_dynamics(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='abs')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            dynamic = dmd2.dynamics[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    np.testing.assert_almost_equal(dmd.dynamics[idx_new],
-                        dynamic, decimal=6)
-                    break
-
-    def test_sorted_eigs_frequency(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='abs')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            frq = dmd2.frequency[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    np.testing.assert_almost_equal(dmd.frequency[idx_new],
-                        frq, decimal=6)
-                    break
-
-    def test_sorted_eigs_amplitudes(self):
-        dmd = DMD(svd_rank=20, sorted_eigs='abs')
-        dmd.fit(sample_data)
-
-        dmd2 = DMD(svd_rank=20)
-        dmd2.fit(sample_data)
-
-        for idx, eig in enumerate(dmd2.eigs):
-            amp = dmd2.amplitudes[idx]
-            for idx_new, eig_new in enumerate(dmd.eigs):
-                if eig_new == eig:
-                    np.testing.assert_almost_equal(dmd.amplitudes[idx_new],
-                        amp, decimal=6)
-                    break
-
-    def test_save(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.save('pydmd.test')
-
-    def test_load(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.save('pydmd.test2')
-        loaded_dmd = DMD.load('pydmd.test2')
-        np.testing.assert_array_equal(dmd.reconstructed_data,
-                                      loaded_dmd.reconstructed_data)
-
-    def test_load(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.save('pydmd.test2')
-        loaded_dmd = DMD.load('pydmd.test2')
-        assert isinstance(loaded_dmd, DMD)
-
-    def test_get_bitmask_default(self):
-        dmd = DMD(svd_rank=10)
-        dmd.fit(X=sample_data)
-        assert np.all(dmd.modes_activation_bitmask == True)
-
-    def test_set_bitmask(self):
-        dmd = DMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
-
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
-
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = DMD(svd_rank=3)
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
-
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = DMD(svd_rank=3)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
-
-    def test_raise_wrong_dtype_bitmask(self):
-        dmd = DMD(svd_rank=3)
-        dmd.fit(X=sample_data)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
-
-    def test_fitted(self):
-        dmd = DMD(svd_rank=3)
-        assert not dmd.fitted
-        dmd.fit(X=sample_data)
-        assert dmd.fitted
-
-    def test_bitmask_amplitudes(self):
-        dmd = DMD(svd_rank=10)
-        dmd.fit(X=sample_data)
-
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
-
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
-
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
-
-    def test_bitmask_eigs(self):
-        dmd = DMD(svd_rank=10)
-        dmd.fit(X=sample_data)
-
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
-
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
-
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
-
-    def test_bitmask_modes(self):
-        dmd = DMD(svd_rank=10)
-        dmd.fit(X=sample_data)
-
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
-
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
-
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
-
-    def test_reconstructed_data(self):
-        dmd = DMD(svd_rank=10)
-        dmd.fit(X=sample_data)
-
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
-
-        dmd.reconstructed_data
-        assert True
-
-    def test_getitem_modes(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        old_n_modes = dmd.modes.shape[1]
-
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
-
-        assert dmd.modes.shape[1] == old_n_modes
-
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
-
-        assert dmd.modes.shape[1] == old_n_modes
-
-        assert dmd[[1,3]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
-
-        assert dmd.modes.shape[1] == old_n_modes
-
-        assert dmd[2].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
-
-        assert dmd.modes.shape[1] == old_n_modes
-
-    def test_getitem_raises(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
-
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        dmd = DMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)
+def test_predict():
+    def f1(x,t):
+        return 1./np.cosh(x+3)*np.exp(2.3j*t)
+
+    def f2(x,t):
+        return 2./np.cosh(x)*np.tanh(x)*np.exp(2.8j*t)
+
+    x = np.linspace(-2, 2, 4)
+    t = np.linspace(0, 4*np.pi, 10)
+
+    xgrid, tgrid = np.meshgrid(x, t)
+
+    X1 = f1(xgrid, tgrid)
+    X2 = f2(xgrid, tgrid)
+    X = X1 + X2
+
+    dmd = DMD()
+    dmd.fit(X.T)
+
+    expected = np.array([
+        [ 0.35407111+0.31966903j,  0.0581077 -0.51616519j,
+            -0.4936891 +0.36476117j,  0.70397844+0.05332291j,
+            -0.56648961-0.50687223j,  0.15372065+0.74444603j,
+            0.30751808-0.63550106j, -0.5633934 +0.24365451j,
+            0.47550633+0.20903766j, -0.0985528 -0.46673545j],
+        [ 0.52924739+0.47782492j,  0.08685642-0.77153733j,
+            -0.73794122+0.54522635j,  1.05227097+0.07970435j,
+            -0.8467597 -0.7576467j ,  0.22977376+1.11275987j,
+            0.4596623 -0.94991449j, -0.84213164+0.3642023j ,
+            0.71076254+0.3124588j , -0.14731169-0.69765229j],
+        [-0.49897731-0.45049592j, -0.0818887 +0.72740958j,
+            0.69573498-0.51404236j, -0.99208678-0.0751457j ,
+            0.79832963+0.71431342j, -0.21663195-1.04911604j,
+            -0.43337211+0.89558454j,  0.79396628-0.3433719j ,
+            -0.67011078-0.29458785j,  0.13888626+0.65775036j],
+        [-0.2717424 -0.2453395j , -0.04459648+0.39614632j,
+            0.37889637-0.2799468j , -0.54028918-0.04092425j,
+            0.43476929+0.38901417j, -0.11797748-0.57134724j,
+            -0.23601389+0.48773418j,  0.43239301-0.18699989j,
+            - 0.36494147 - 0.16043216j, 0.07563728 + 0.35821j]
+    ])
+
+    np.testing.assert_almost_equal(dmd.predict(X.T), expected, decimal=6)
+
+def test_predict_exact():
+    dmd = DMD(exact=True)
+    expected = np.load('tests/test_datasets/input_sample_predict_exact.npy')
+
+    np.testing.assert_almost_equal(dmd
+        .fit(sample_data)
+        .predict(sample_data[:,20:40]), expected, decimal=6)
+
+def test_predict_nexact():
+    dmd = DMD(exact=False)
+    expected = np.load('tests/test_datasets/input_sample_predict_nexact.npy')
+
+    np.testing.assert_almost_equal(dmd
+        .fit(sample_data)
+        .predict(sample_data[:, 10:30]), expected, decimal=6)
+
+
+def test_advanced_snapshot_parameter():
+    dmd = DMD(svd_rank=0.99)
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=0.99, opt=-1)
+    dmd2.fit(sample_data)
+
+    np.testing.assert_almost_equal(dmd2.reconstructed_data.real,
+        dmd.reconstructed_data.real, decimal=6)
+
+
+def test_sorted_eigs_default():
+    dmd = DMD()
+    assert dmd.operator._sorted_eigs == False
+
+def test_sorted_eigs_set_real():
+    dmd = DMD(sorted_eigs='real')
+    assert dmd.operator._sorted_eigs == 'real'
+
+def test_sorted_eigs_abs_right_eigs():
+    dmd = DMD(svd_rank=20, sorted_eigs='abs')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    assert len(dmd.eigs) == len(dmd2.eigs)
+    assert set(dmd.eigs) == set(dmd2.eigs)
+
+    previous = dmd.eigs[0]
+    for eig in dmd.eigs[1:]:
+        assert abs(previous) <= abs(eig)
+        previous = eig
+
+def test_sorted_eigs_abs_right_eigenvectors():
+    dmd = DMD(svd_rank=20, sorted_eigs='abs')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        eigenvector = dmd2.operator.eigenvectors.T[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                assert all(dmd.operator.eigenvectors.T[idx_new] == eigenvector)
+                break
+
+def test_sorted_eigs_abs_right_modes():
+    dmd = DMD(svd_rank=20, sorted_eigs='abs')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        mode = dmd2.modes.T[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                np.testing.assert_almost_equal(dmd.modes.T[idx_new], mode,
+                    decimal=6)
+                break
+
+def test_sorted_eigs_real_right_eigs():
+    dmd = DMD(svd_rank=20, sorted_eigs='real')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    assert len(dmd.eigs) == len(dmd2.eigs)
+    assert set(dmd.eigs) == set(dmd2.eigs)
+
+    previous = complex(dmd.eigs[0])
+    for eig in dmd.eigs[1:]:
+        x = complex(eig)
+        assert x.real > previous.real or (x.real == previous.real and x.imag >= previous.imag)
+        previous = x
+
+def test_sorted_eigs_real_right_eigenvectors():
+    dmd = DMD(svd_rank=20, sorted_eigs='real')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        eigenvector = dmd2.operator.eigenvectors.T[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                assert all(dmd.operator.eigenvectors.T[idx_new] == eigenvector)
+                break
+
+def test_sorted_eigs_real_right_modes():
+    dmd = DMD(svd_rank=20, sorted_eigs='real')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        mode = dmd2.modes.T[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                np.testing.assert_almost_equal(dmd.modes.T[idx_new], mode,
+                    decimal=6)
+                break
+
+def test_sorted_eigs_dynamics():
+    dmd = DMD(svd_rank=20, sorted_eigs='abs')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        dynamic = dmd2.dynamics[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                np.testing.assert_almost_equal(dmd.dynamics[idx_new],
+                    dynamic, decimal=6)
+                break
+
+def test_sorted_eigs_frequency():
+    dmd = DMD(svd_rank=20, sorted_eigs='abs')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        frq = dmd2.frequency[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                np.testing.assert_almost_equal(dmd.frequency[idx_new],
+                    frq, decimal=6)
+                break
+
+def test_sorted_eigs_amplitudes():
+    dmd = DMD(svd_rank=20, sorted_eigs='abs')
+    dmd.fit(sample_data)
+
+    dmd2 = DMD(svd_rank=20)
+    dmd2.fit(sample_data)
+
+    for idx, eig in enumerate(dmd2.eigs):
+        amp = dmd2.amplitudes[idx]
+        for idx_new, eig_new in enumerate(dmd.eigs):
+            if eig_new == eig:
+                np.testing.assert_almost_equal(dmd.amplitudes[idx_new],
+                    amp, decimal=6)
+                break
+
+def test_save():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.save('pydmd.test')
+
+def test_load():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.save('pydmd.test2')
+    loaded_dmd = DMD.load('pydmd.test2')
+    np.testing.assert_array_equal(dmd.reconstructed_data,
+                                    loaded_dmd.reconstructed_data)
+
+def test_load():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.save('pydmd.test2')
+    loaded_dmd = DMD.load('pydmd.test2')
+    assert isinstance(loaded_dmd, DMD)
+
+def test_get_bitmask_default():
+    dmd = DMD(svd_rank=10)
+    dmd.fit(X=sample_data)
+    assert np.all(dmd.modes_activation_bitmask == True)
+
+def test_set_bitmask():
+    dmd = DMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
+
+def test_not_fitted_get_bitmask_raises():
+    dmd = DMD(svd_rank=3)
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
+
+def test_not_fitted_set_bitmask_raises():
+    dmd = DMD(svd_rank=3)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+
+def test_raise_wrong_dtype_bitmask():
+    dmd = DMD(svd_rank=3)
+    dmd.fit(X=sample_data)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
+
+def test_fitted():
+    dmd = DMD(svd_rank=3)
+    assert not dmd.fitted
+    dmd.fit(X=sample_data)
+    assert dmd.fitted
+
+def test_bitmask_amplitudes():
+    dmd = DMD(svd_rank=10)
+    dmd.fit(X=sample_data)
+
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+
+def test_bitmask_eigs():
+    dmd = DMD(svd_rank=10)
+    dmd.fit(X=sample_data)
+
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
+
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+
+def test_bitmask_modes():
+    dmd = DMD(svd_rank=10)
+    dmd.fit(X=sample_data)
+
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
+
+def test_reconstructed_data():
+    dmd = DMD(svd_rank=10)
+    dmd.fit(X=sample_data)
+
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    dmd.reconstructed_data
+    assert True
+
+def test_getitem_modes():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    old_n_modes = dmd.modes.shape[1]
+
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+    assert dmd[[1,3]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+    assert dmd[2].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+def test_getitem_raises():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
+
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    dmd = DMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
 from pydmd.dmdbase import DMDBase
 from pydmd import DMD
 import matplotlib.pyplot as plt
 import numpy as np
+from pytest import raises
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -11,143 +11,142 @@ import numpy as np
 sample_data = np.load('tests/test_datasets/input_sample.npy')
 
 
-class TestDmdBase(TestCase):
-    def test_svd_rank_default(self):
-        dmd = DMDBase()
-        assert dmd.svd_rank == 0
+def test_svd_rank_default():
+    dmd = DMDBase()
+    assert dmd.svd_rank == 0
 
-    def test_svd_rank(self):
-        dmd = DMDBase(svd_rank=3)
-        assert dmd.svd_rank == 3
+def test_svd_rank():
+    dmd = DMDBase(svd_rank=3)
+    assert dmd.svd_rank == 3
 
-    def test_tlsq_rank_default(self):
-        dmd = DMDBase()
-        assert dmd.tlsq_rank == 0
+def test_tlsq_rank_default():
+    dmd = DMDBase()
+    assert dmd.tlsq_rank == 0
 
-    def test_tlsq_rank(self):
-        dmd = DMDBase(tlsq_rank=2)
-        assert dmd.tlsq_rank == 2
+def test_tlsq_rank():
+    dmd = DMDBase(tlsq_rank=2)
+    assert dmd.tlsq_rank == 2
 
-    def test_exact_default(self):
-        dmd = DMDBase()
-        assert dmd.exact == False
+def test_exact_default():
+    dmd = DMDBase()
+    assert dmd.exact == False
 
-    def test_exact(self):
-        dmd = DMDBase(exact=True)
-        assert dmd.exact == True
+def test_exact():
+    dmd = DMDBase(exact=True)
+    assert dmd.exact == True
 
-    def test_opt_default(self):
-        dmd = DMDBase()
-        assert dmd.opt == False
+def test_opt_default():
+    dmd = DMDBase()
+    assert dmd.opt == False
 
-    def test_opt(self):
-        dmd = DMDBase(opt=True)
-        assert dmd.opt == True
+def test_opt():
+    dmd = DMDBase(opt=True)
+    assert dmd.opt == True
 
-    def test_fit(self):
-        dmd = DMDBase(exact=False)
-        with self.assertRaises(NotImplementedError):
-            dmd.fit(sample_data)
-
-    def test_plot_eigs(self):
-        dmd = DMDBase()
-        with self.assertRaises(ValueError):
-            dmd.plot_eigs(show_axes=True, show_unit_circle=True)
-
-    def test_plot_eigs_narrowview_empty(self):
-        dmd = DMDBase()
-        # max/min throws an error if the array is empty (max used on empty
-        # array)
-        dmd.operator._eigenvalues = np.array([], dtype=complex)
-        with self.assertRaises(ValueError):
-            dmd.plot_eigs(show_axes=False, narrow_view=True, dpi=200)
-
-    def test_plot_modes_2D(self):
-        dmd = DMDBase()
-        with self.assertRaises(ValueError):
-            dmd.plot_modes_2D()
-
-    def test_plot_snaps_2D(self):
-        dmd = DMDBase()
-        with self.assertRaises(ValueError):
-            dmd.plot_snapshots_2D()
-
-    def test_advanced_snapshot_parameter2(self):
-        dmd = DMDBase(opt=5)
-        assert dmd.opt == 5
-
-    def test_translate_tpow_positive(self):
-        dmd = DMDBase(opt=4)
-
-        assert dmd._translate_eigs_exponent(10) == 6
-        assert dmd._translate_eigs_exponent(0) == -4
-
-    def test_translate_tpow_negative(self):
-        dmd = DMDBase(opt=-1)
-        dmd._snapshots = sample_data
-
-        assert dmd._translate_eigs_exponent(10) == 10 - (sample_data.shape[1] - 1)
-        assert dmd._translate_eigs_exponent(0) == 1 - sample_data.shape[1]
-
-    def test_translate_tpow_vector(self):
-        dmd = DMDBase(opt=-1)
-        dmd._snapshots = sample_data
-
-        tpow = np.ndarray([0,1,2,3,5,6,7,11])
-        for idx,x in enumerate(dmd._translate_eigs_exponent(tpow)):
-            assert x == dmd._translate_eigs_exponent(tpow[idx])
-
-    def test_sorted_eigs_default(self):
-        dmd = DMDBase()
-        assert dmd.operator._sorted_eigs == False
-
-    def test_sorted_eigs_param(self):
-        dmd = DMDBase(sorted_eigs='real')
-        assert dmd.operator._sorted_eigs == 'real'
-
-    def test_enforce_ratio_y(self):
-        dmd = DMDBase()
-        supx, infx, supy, infy = dmd._enforce_ratio(10, 20, 10, 0, 0)
-
-        dx = supx - infx
-        dy = supy - infy
-        np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)
-
-    def test_enforce_ratio_x(self):
-        dmd = DMDBase()
-        supx, infx, supy, infy = dmd._enforce_ratio(10, 0, 0, 20, 10)
-
-        dx = supx - infx
-        dy = supy - infy
-        np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)
-
-
-    def test_plot_limits_narrow(self):
-        dmd = DMDBase()
-        dmd.operator._eigenvalues = np.array([complex(1,2), complex(-1,-2)])
-        dmd.operator._modes = np.array(np.ones((10,2)))
-
-        tp = dmd._plot_limits(True)
-
-        assert len(tp) == 4
-
-        supx, infx, supy, infy = tp
-        assert supx == 1.05
-        assert infx == -1.05
-        assert supy == 2.05
-        assert infy == -2.05
-
-    def test_plot_limits(self):
-        dmd = DMDBase()
-        dmd.operator._eigenvalues = np.array([complex(-2,2), complex(3,-3)])
-        dmd.operator._modes = np.array(np.ones((10,2)))
-
-        limit = dmd._plot_limits(False)
-        assert limit == 5
-
-    def test_dmd_time_wrong_key(self):
-        dmd = DMD(svd_rank=10)
+def test_fit():
+    dmd = DMDBase(exact=False)
+    with raises(NotImplementedError):
         dmd.fit(sample_data)
 
-        with self.assertRaises(KeyError):
-            dmd.dmd_time['tstart'] = 10
+def test_plot_eigs():
+    dmd = DMDBase()
+    with raises(ValueError):
+        dmd.plot_eigs(show_axes=True, show_unit_circle=True)
+
+def test_plot_eigs_narrowview_empty():
+    dmd = DMDBase()
+    # max/min throws an error if the array is empty (max used on empty
+    # array)
+    dmd.operator._eigenvalues = np.array([], dtype=complex)
+    with raises(ValueError):
+        dmd.plot_eigs(show_axes=False, narrow_view=True, dpi=200)
+
+def test_plot_modes_2D():
+    dmd = DMDBase()
+    with raises(ValueError):
+        dmd.plot_modes_2D()
+
+def test_plot_snaps_2D():
+    dmd = DMDBase()
+    with raises(ValueError):
+        dmd.plot_snapshots_2D()
+
+def test_advanced_snapshot_parameter2():
+    dmd = DMDBase(opt=5)
+    assert dmd.opt == 5
+
+def test_translate_tpow_positive():
+    dmd = DMDBase(opt=4)
+
+    assert dmd._translate_eigs_exponent(10) == 6
+    assert dmd._translate_eigs_exponent(0) == -4
+
+def test_translate_tpow_negative():
+    dmd = DMDBase(opt=-1)
+    dmd._snapshots = sample_data
+
+    assert dmd._translate_eigs_exponent(10) == 10 - (sample_data.shape[1] - 1)
+    assert dmd._translate_eigs_exponent(0) == 1 - sample_data.shape[1]
+
+def test_translate_tpow_vector():
+    dmd = DMDBase(opt=-1)
+    dmd._snapshots = sample_data
+
+    tpow = np.ndarray([0,1,2,3,5,6,7,11])
+    for idx,x in enumerate(dmd._translate_eigs_exponent(tpow)):
+        assert x == dmd._translate_eigs_exponent(tpow[idx])
+
+def test_sorted_eigs_default():
+    dmd = DMDBase()
+    assert dmd.operator._sorted_eigs == False
+
+def test_sorted_eigs_param():
+    dmd = DMDBase(sorted_eigs='real')
+    assert dmd.operator._sorted_eigs == 'real'
+
+def test_enforce_ratio_y():
+    dmd = DMDBase()
+    supx, infx, supy, infy = dmd._enforce_ratio(10, 20, 10, 0, 0)
+
+    dx = supx - infx
+    dy = supy - infy
+    np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)
+
+def test_enforce_ratio_x():
+    dmd = DMDBase()
+    supx, infx, supy, infy = dmd._enforce_ratio(10, 0, 0, 20, 10)
+
+    dx = supx - infx
+    dy = supy - infy
+    np.testing.assert_almost_equal(max(dx,dy) / min(dx,dy), 10, decimal=6)
+
+
+def test_plot_limits_narrow():
+    dmd = DMDBase()
+    dmd.operator._eigenvalues = np.array([complex(1,2), complex(-1,-2)])
+    dmd.operator._modes = np.array(np.ones((10,2)))
+
+    tp = dmd._plot_limits(True)
+
+    assert len(tp) == 4
+
+    supx, infx, supy, infy = tp
+    assert supx == 1.05
+    assert infx == -1.05
+    assert supy == 2.05
+    assert infy == -2.05
+
+def test_plot_limits():
+    dmd = DMDBase()
+    dmd.operator._eigenvalues = np.array([complex(-2,2), complex(3,-3)])
+    dmd.operator._modes = np.array(np.ones((10,2)))
+
+    limit = dmd._plot_limits(False)
+    assert limit == 5
+
+def test_dmd_time_wrong_key():
+    dmd = DMD(svd_rank=10)
+    dmd.fit(sample_data)
+
+    with raises(KeyError):
+        dmd.dmd_time['tstart'] = 10

--- a/tests/test_dmdc.py
+++ b/tests/test_dmdc.py
@@ -1,10 +1,10 @@
 from __future__ import division
 from past.utils import old_div
-from unittest import TestCase
 from pydmd import DMDc
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy
+from pytest import raises
 
 
 def create_system_with_B():
@@ -28,192 +28,191 @@ def create_system_without_B():
     return {'snapshots': snapshots, 'u': u, 'B': B, 'A': A}
 
 
-class TestDMDC(TestCase):
-    def test_eigs_b_known(self):
-        system = create_system_with_B()
-        dmdc = DMDc(svd_rank=-1)
-        dmdc.fit(system['snapshots'], system['u'], system['B'])
-        real_eigs = np.array([0.1, 1.5])
-        np.testing.assert_array_almost_equal(dmdc.eigs, real_eigs)
+def test_eigs_b_known():
+    system = create_system_with_B()
+    dmdc = DMDc(svd_rank=-1)
+    dmdc.fit(system['snapshots'], system['u'], system['B'])
+    real_eigs = np.array([0.1, 1.5])
+    np.testing.assert_array_almost_equal(dmdc.eigs, real_eigs)
 
-    def test_eigs_b_unknown(self):
-        system = create_system_without_B()
-        dmdc = DMDc(svd_rank=3, opt=False, svd_rank_omega=4)
-        dmdc.fit(system['snapshots'], system['u'])
-        self.assertEqual(dmdc.eigs.shape[0], 3)
+def test_eigs_b_unknown():
+    system = create_system_without_B()
+    dmdc = DMDc(svd_rank=3, opt=False, svd_rank_omega=4)
+    dmdc.fit(system['snapshots'], system['u'])
+    assert dmdc.eigs.shape[0] == 3
 
-    def test_modes_b_unknown(self):
-        system = create_system_without_B()
-        dmdc = DMDc(svd_rank=3, opt=False, svd_rank_omega=4)
-        dmdc.fit(system['snapshots'], system['u'])
-        self.assertEqual(dmdc.modes.shape[1], 3)
+def test_modes_b_unknown():
+    system = create_system_without_B()
+    dmdc = DMDc(svd_rank=3, opt=False, svd_rank_omega=4)
+    dmdc.fit(system['snapshots'], system['u'])
+    assert dmdc.modes.shape[1] == 3
 
-    def test_reconstruct_b_known(self):
-        system = create_system_with_B()
-        dmdc = DMDc(svd_rank=-1)
-        dmdc.fit(system['snapshots'], system['u'], system['B'])
-        np.testing.assert_array_almost_equal(dmdc.reconstructed_data(),
-                                             system['snapshots'])
+def test_reconstruct_b_known():
+    system = create_system_with_B()
+    dmdc = DMDc(svd_rank=-1)
+    dmdc.fit(system['snapshots'], system['u'], system['B'])
+    np.testing.assert_array_almost_equal(dmdc.reconstructed_data(),
+                                            system['snapshots'])
 
-    def test_B_b_known(self):
-        system = create_system_with_B()
-        dmdc = DMDc(svd_rank=-1)
-        dmdc.fit(system['snapshots'], system['u'], system['B'])
-        np.testing.assert_array_almost_equal(dmdc.B, system['B'])
+def test_B_b_known():
+    system = create_system_with_B()
+    dmdc = DMDc(svd_rank=-1)
+    dmdc.fit(system['snapshots'], system['u'], system['B'])
+    np.testing.assert_array_almost_equal(dmdc.B, system['B'])
 
-    def test_reconstruct_b_unknown(self):
-        system = create_system_without_B()
-        dmdc = DMDc(svd_rank=-1, opt=True)
-        dmdc.fit(system['snapshots'], system['u'])
-        np.testing.assert_array_almost_equal(
-            dmdc.reconstructed_data(), system['snapshots'], decimal=6)
+def test_reconstruct_b_unknown():
+    system = create_system_without_B()
+    dmdc = DMDc(svd_rank=-1, opt=True)
+    dmdc.fit(system['snapshots'], system['u'])
+    np.testing.assert_array_almost_equal(
+        dmdc.reconstructed_data(), system['snapshots'], decimal=6)
 
-    def test_atilde_b_unknown(self):
-        system = create_system_without_B()
-        dmdc = DMDc(svd_rank=-1, opt=True)
-        dmdc.fit(system['snapshots'], system['u'])
-        expected_atilde = dmdc.basis.T.conj().dot(system['A']).dot(dmdc.basis)
-        np.testing.assert_array_almost_equal(
-            dmdc.atilde, expected_atilde, decimal=1)
+def test_atilde_b_unknown():
+    system = create_system_without_B()
+    dmdc = DMDc(svd_rank=-1, opt=True)
+    dmdc.fit(system['snapshots'], system['u'])
+    expected_atilde = dmdc.basis.T.conj().dot(system['A']).dot(dmdc.basis)
+    np.testing.assert_array_almost_equal(
+        dmdc.atilde, expected_atilde, decimal=1)
 
-    def test_get_bitmask_default(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
-        assert np.all(dmd.modes_activation_bitmask == True)
+def test_get_bitmask_default():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
+    assert np.all(dmd.modes_activation_bitmask == True)
 
-    def test_set_bitmask(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
+def test_set_bitmask():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
 
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
 
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = DMDc(svd_rank=-1, opt=True)
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
+def test_not_fitted_get_bitmask_raises():
+    dmd = DMDc(svd_rank=-1, opt=True)
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
 
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = DMDc(svd_rank=-1, opt=True)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+def test_not_fitted_set_bitmask_raises():
+    dmd = DMDc(svd_rank=-1, opt=True)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
 
-    def test_raise_wrong_dtype_bitmask(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
+def test_raise_wrong_dtype_bitmask():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
 
-    def test_fitted(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        assert not dmd.fitted
-        dmd.fit(system['snapshots'], system['u'], system['B'])
-        assert dmd.fitted
+def test_fitted():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    assert not dmd.fitted
+    dmd.fit(system['snapshots'], system['u'], system['B'])
+    assert dmd.fitted
 
-    def test_bitmask_amplitudes(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
+def test_bitmask_amplitudes():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
 
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
 
-    def test_bitmask_eigs(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
+def test_bitmask_eigs():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
 
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
 
-    def test_bitmask_modes(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
+def test_bitmask_modes():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
 
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-    def test_reconstructed_data(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1, opt=True)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
+def test_reconstructed_data():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1, opt=True)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        dmd.reconstructed_data
-        assert True
+    dmd.reconstructed_data
+    assert True
 
-    def test_getitem_modes(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
-        old_n_modes = dmd.modes.shape[1]
+def test_getitem_modes():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
+    old_n_modes = dmd.modes.shape[1]
 
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[1].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[1].modes), dmd.modes[:,1])
+    assert dmd[1].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[1].modes), dmd.modes[:,1])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-    def test_getitem_raises(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
+def test_getitem_raises():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
 
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
 
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        system = create_system_with_B()
-        dmd = DMDc(svd_rank=-1)
-        dmd.fit(system['snapshots'], system['u'], system['B'])
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    system = create_system_with_B()
+    dmd = DMDc(svd_rank=-1)
+    dmd.fit(system['snapshots'], system['u'], system['B'])
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_dmdoperator.py
+++ b/tests/test_dmdoperator.py
@@ -1,7 +1,8 @@
 from builtins import range
-from unittest import TestCase
 import numpy as np
 import os
+
+from pytest import raises
 
 from pydmd.dmdoperator import DMDOperator
 from pydmd.utils import compute_tlsq
@@ -14,91 +15,90 @@ import matplotlib.pyplot as plt
 # f2 = lambda x,t: (sech(x)*np.tanh(x))*(2.*np.exp(1j*2.8*t))
 sample_data = np.load('tests/test_datasets/input_sample.npy')
 
-class TestDmdOperator(TestCase):
-    def test_constructor(self):
-        operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
+def test_constructor():
+    operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
+        rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
 
-        assert operator._svd_rank == 2
-        assert operator._exact == True
-        assert operator._forward_backward == False
-        assert operator._rescale_mode == 'auto'
+    assert operator._svd_rank == 2
+    assert operator._exact == True
+    assert operator._forward_backward == False
+    assert operator._rescale_mode == 'auto'
 
-    def test_noncompute_error(self):
-        operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
+def test_noncompute_error():
+    operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
+        rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
 
-        with self.assertRaises(ValueError):
-            operator.shape
+    with raises(ValueError):
+        operator.shape
 
-        with self.assertRaises(ValueError):
-            operator.Lambda
+    with raises(ValueError):
+        operator.Lambda
 
-        with self.assertRaises(ValueError):
-            operator.modes
+    with raises(ValueError):
+        operator.modes
 
-        with self.assertRaises(ValueError):
-            operator.eigenvalues
+    with raises(ValueError):
+        operator.eigenvalues
 
-        with self.assertRaises(ValueError):
-            operator.eigenvectors
+    with raises(ValueError):
+        operator.eigenvectors
 
-        with self.assertRaises(ValueError):
-            operator.as_numpy_array
+    with raises(ValueError):
+        operator.as_numpy_array
 
-    def test_compute_operator(self):
-        operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
+def test_compute_operator():
+    operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
+        rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
+    operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
+
+    assert operator.as_numpy_array is not None
+    assert operator.eigenvalues is not None
+    assert operator.eigenvectors is not None
+    assert operator.modes is not None
+    assert operator.Lambda is not None
+
+# test that a value of 'auto' in rescale_mode is replaced by the singular
+# values of X
+def test_rescalemode_auto_singular_values():
+    operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
+        rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
+    operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
+    np.testing.assert_almost_equal(operator._rescale_mode, np.array([3.]),
+        decimal=1)
+
+def test_call():
+    operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
+        rescale_mode=None, sorted_eigs=False, tikhonov_regularization=None)
+
+    X = sample_data[:, :-1]
+    Y = sample_data[:, 1:]
+    X, Y = compute_tlsq(X, Y, 0)
+
+    operator.compute_operator(X,Y)
+
+    expected = np.array([-0.47643628 + 0.87835227j, -0.47270971 + 0.88160808j])
+
+    np.testing.assert_almost_equal(operator(np.ones(2)), expected, decimal=6)
+
+def test_compute_eigenquantities_wrong_rescalemode():
+    operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
+        rescale_mode=4, sorted_eigs=False, tikhonov_regularization=None)
+    with raises(ValueError):
         operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
 
-        assert operator.as_numpy_array is not None
-        assert operator.eigenvalues is not None
-        assert operator.eigenvectors is not None
-        assert operator.modes is not None
-        assert operator.Lambda is not None
-
-    # test that a value of 'auto' in rescale_mode is replaced by the singular
-    # values of X
-    def test_rescalemode_auto_singular_values(self):
-        operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode='auto', sorted_eigs=False, tikhonov_regularization=None)
+    operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
+        rescale_mode=np.ones((4,)), sorted_eigs=False, tikhonov_regularization=None)
+    with raises(ValueError):
         operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
-        np.testing.assert_almost_equal(operator._rescale_mode, np.array([3.]),
-            decimal=1)
 
-    def test_call(self):
-        operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode=None, sorted_eigs=False, tikhonov_regularization=None)
+def test_plot_operator():
+    operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
+        rescale_mode=None, sorted_eigs=False, tikhonov_regularization=None)
 
-        X = sample_data[:, :-1]
-        Y = sample_data[:, 1:]
-        X, Y = compute_tlsq(X, Y, 0)
+    X = sample_data[:, :-1]
+    Y = sample_data[:, 1:]
+    X, Y = compute_tlsq(X, Y, 0)
 
-        operator.compute_operator(X,Y)
-
-        expected = np.array([-0.47643628 + 0.87835227j, -0.47270971 + 0.88160808j])
-
-        np.testing.assert_almost_equal(operator(np.ones(2)), expected, decimal=6)
-
-    def test_compute_eigenquantities_wrong_rescalemode(self):
-        operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode=4, sorted_eigs=False, tikhonov_regularization=None)
-        with self.assertRaises(ValueError):
-            operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
-
-        operator = DMDOperator(svd_rank=0, exact=True, forward_backward=False,
-            rescale_mode=np.ones((4,)), sorted_eigs=False, tikhonov_regularization=None)
-        with self.assertRaises(ValueError):
-            operator.compute_operator(np.ones((3, 3)), np.ones((3, 3)))
-
-    def test_plot_operator(self):
-        operator = DMDOperator(svd_rank=2, exact=True, forward_backward=False,
-            rescale_mode=None, sorted_eigs=False, tikhonov_regularization=None)
-
-        X = sample_data[:, :-1]
-        Y = sample_data[:, 1:]
-        X, Y = compute_tlsq(X, Y, 0)
-
-        operator.compute_operator(X, Y)
-        operator.plot_operator()
-        plt.close()
+    operator.compute_operator(X, Y)
+    operator.plot_operator()
+    plt.close()

--- a/tests/test_fbdmd.py
+++ b/tests/test_fbdmd.py
@@ -1,8 +1,8 @@
 from builtins import range
-from unittest import TestCase
 from pydmd.fbdmd import FbDMD
 import matplotlib.pyplot as plt
 import numpy as np
+from pytest import raises
 
 
 def create_noisy_data():
@@ -25,203 +25,202 @@ def create_noisy_data():
 sample_data = create_noisy_data()
 
 
-class TestFbDmd(TestCase):
-    def test_modes_shape(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == 2
+def test_modes_shape():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == 2
 
-    def test_truncation_shape(self):
-        dmd = FbDMD(svd_rank=1)
-        dmd.fit(X=sample_data)
-        assert dmd.modes.shape[1] == 1
+def test_truncation_shape():
+    dmd = FbDMD(svd_rank=1)
+    dmd.fit(X=sample_data)
+    assert dmd.modes.shape[1] == 1
 
-    def test_dynamics(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert dmd.dynamics.shape == (2, 100)
+def test_dynamics():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert dmd.dynamics.shape == (2, 100)
 
-    def test_eigs_1(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 2
+def test_eigs_1():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 2
 
-    def test_eigs_2(self):
-        dmd = FbDMD(svd_rank=1)
-        dmd.fit(X=sample_data)
-        assert len(dmd.eigs) == 1
+def test_eigs_2():
+    dmd = FbDMD(svd_rank=1)
+    dmd.fit(X=sample_data)
+    assert len(dmd.eigs) == 1
 
-    def test_eigs_modulus_1(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        np.testing.assert_almost_equal(
-            np.linalg.norm(dmd.eigs[0]), 1., decimal=6)
+def test_eigs_modulus_1():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    np.testing.assert_almost_equal(
+        np.linalg.norm(dmd.eigs[0]), 1., decimal=6)
 
-    def test_eigs_modulus_2(self):
-        dmd = FbDMD(svd_rank=-1, exact=True)
-        dmd.fit(X=sample_data)
-        np.testing.assert_almost_equal(
-            np.linalg.norm(dmd.eigs[1]), 1., decimal=6)
+def test_eigs_modulus_2():
+    dmd = FbDMD(svd_rank=-1, exact=True)
+    dmd.fit(X=sample_data)
+    np.testing.assert_almost_equal(
+        np.linalg.norm(dmd.eigs[1]), 1., decimal=6)
 
-    def test_reconstructed_data(self):
-        dmd = FbDMD(exact=True, svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd_data = dmd.reconstructed_data
-        dmd_data_correct = np.load('tests/test_datasets/fbdmd_data.npy')
-        assert np.allclose(dmd_data, dmd_data_correct)
+def test_reconstructed_data():
+    dmd = FbDMD(exact=True, svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd_data = dmd.reconstructed_data
+    dmd_data_correct = np.load('tests/test_datasets/fbdmd_data.npy')
+    assert np.allclose(dmd_data, dmd_data_correct)
 
-    def test_plot_eigs_1(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=True, show_unit_circle=True)
-        plt.close()
+def test_plot_eigs_1():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=True, show_unit_circle=True)
+    plt.close()
 
-    def test_plot_eigs_2(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        dmd.plot_eigs(show_axes=False, show_unit_circle=False)
-        plt.close()
+def test_plot_eigs_2():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    dmd.plot_eigs(show_axes=False, show_unit_circle=False)
+    plt.close()
 
-    def test_sorted_eigs_default(self):
-        dmd = FbDMD(svd_rank=-1)
-        assert dmd.operator._sorted_eigs == False
+def test_sorted_eigs_default():
+    dmd = FbDMD(svd_rank=-1)
+    assert dmd.operator._sorted_eigs == False
 
-    def test_sorted_eigs_param(self):
-        dmd = FbDMD(svd_rank=-1, sorted_eigs='real')
-        assert dmd.operator._sorted_eigs == 'real'
+def test_sorted_eigs_param():
+    dmd = FbDMD(svd_rank=-1, sorted_eigs='real')
+    assert dmd.operator._sorted_eigs == 'real'
 
-    def test_get_bitmask_default(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        assert np.all(dmd.modes_activation_bitmask == True)
+def test_get_bitmask_default():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    assert np.all(dmd.modes_activation_bitmask == True)
 
-    def test_set_bitmask(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
+def test_set_bitmask():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
 
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
 
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = FbDMD(svd_rank=-1)
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
+def test_not_fitted_get_bitmask_raises():
+    dmd = FbDMD(svd_rank=-1)
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
 
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = FbDMD(svd_rank=-1)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+def test_not_fitted_set_bitmask_raises():
+    dmd = FbDMD(svd_rank=-1)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
 
-    def test_raise_wrong_dtype_bitmask(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
+def test_raise_wrong_dtype_bitmask():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
 
-    def test_fitted(self):
-        dmd = FbDMD(svd_rank=-1)
-        assert not dmd.fitted
-        dmd.fit(X=sample_data)
-        assert dmd.fitted
+def test_fitted():
+    dmd = FbDMD(svd_rank=-1)
+    assert not dmd.fitted
+    dmd.fit(X=sample_data)
+    assert dmd.fitted
 
-    def test_bitmask_amplitudes(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
+def test_bitmask_amplitudes():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
 
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
 
-    def test_bitmask_eigs(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
+def test_bitmask_eigs():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
 
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
 
-    def test_bitmask_modes(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
+def test_bitmask_modes():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
 
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-    def test_reconstructed_data(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=sample_data)
+def test_reconstructed_data():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=sample_data)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        dmd.reconstructed_data
-        assert True
+    dmd.reconstructed_data
+    assert True
 
-    def test_getitem_modes(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
-        old_n_modes = dmd.modes.shape[1]
+def test_getitem_modes():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
+    old_n_modes = dmd.modes.shape[1]
 
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[[1,3]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+    assert dmd[[1,3]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-        assert dmd[2].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+    assert dmd[2].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.modes.shape[1] == old_n_modes
 
-    def test_getitem_raises(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
+def test_getitem_raises():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
 
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
 
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        dmd = FbDMD(svd_rank=-1)
-        dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    dmd = FbDMD(svd_rank=-1)
+    dmd.fit(X=np.load('tests/test_datasets/input_sample.npy'))
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,19 +1,16 @@
-from unittest import TestCase
-import unittest
 import pkgutil
 from os import walk
 from os import path
 
 
-class TestPackage(TestCase):
-    def test_import_dm_1(self):
-        import pydmd as dm
-        dmd = dm.dmd.DMDBase()
+def test_import_dm_1():
+    import pydmd as dm
+    dmd = dm.dmd.DMDBase()
 
-    def test_import_dm_2(self):
-        import pydmd as dm
-        dmd = dm.dmd.DMD()
+def test_import_dm_2():
+    import pydmd as dm
+    dmd = dm.dmd.DMD()
 
-    def test_import_dm_3(self):
-        import pydmd as dm
-        dmd = dm.fbdmd.FbDMD()
+def test_import_dm_3():
+    import pydmd as dm
+    dmd = dm.fbdmd.FbDMD()

--- a/tests/test_spdmd.py
+++ b/tests/test_spdmd.py
@@ -1,296 +1,295 @@
-from unittest import TestCase
 from pydmd import SpDMD, DMD
 import scipy.io
 import numpy as np
+from pytest import raises
 
 data = np.load("tests/test_datasets/heat_90.npy")
 gammas = [1.0e-1, 0.5, 2, 5, 10, 20, 40, 50, 100]
 
 
-class TestSpDmd(TestCase):
-    def test_number_nonzero_amplitudes_rho1(self):
-        zeros = np.load("tests/test_datasets/zero_amplitudes_rho1.npy")
+def test_number_nonzero_amplitudes_rho1():
+    zeros = np.load("tests/test_datasets/zero_amplitudes_rho1.npy")
 
-        for gm, z in zip(gammas, zeros.T):
-            assert all(
-                SpDMD(
-                    svd_rank=30,
-                    gamma=gm,
-                    release_memory=False,
-                )
-                .fit(data)
-                ._find_zero_amplitudes()
-                == z
+    for gm, z in zip(gammas, zeros.T):
+        assert all(
+            SpDMD(
+                svd_rank=30,
+                gamma=gm,
+                release_memory=False,
             )
-
-    def test_number_nonzero_amplitudes_rho1e4(self):
-        zeros = np.load("tests/test_datasets/zero_amplitudes_rho1e4.npy")
-
-        for gm, z in zip(gammas, zeros.T):
-            assert all(
-                SpDMD(
-                    svd_rank=30,
-                    gamma=gm,
-                    rho=1.0e4,
-                    release_memory=False,
-                )
-                .fit(data)
-                ._find_zero_amplitudes()
-                == z
-            )
-
-
-    def test_spdmd_amplitudes_rho1(self):
-        amps = np.load("tests/test_datasets/spdmd_amplitudes_rho1.npy")
-
-        for gm, z in zip(gammas, amps.T):
-            np.testing.assert_allclose(
-                SpDMD(
-                    svd_rank=30,
-                    gamma=gm,
-                )
-                .fit(data)
-                .amplitudes,
-                z,
-                rtol=2,
-                atol=1.e-6
-            )
-
-    def test_spdmd_amplitudes_rho1e4(self):
-        amps = np.load("tests/test_datasets/spdmd_amplitudes_rho1e4.npy")
-
-        for gm, z in zip(gammas, amps.T):
-            np.testing.assert_allclose(
-                SpDMD(svd_rank=30, gamma=gm, rho=1.0e4).fit(data).amplitudes,
-                z,
-                rtol=2,
-                atol=1.e-6
-            )
-
-    def test_rho(self):
-        assert SpDMD().rho == 1
-        assert SpDMD(rho=10).rho == 10
-
-    def test_maxiter(self):
-        assert SpDMD()._max_iterations == 10000
-        assert SpDMD(max_iterations=2)._max_iterations == 2
-
-    def test_gamma(self):
-        assert SpDMD().gamma == 10
-        assert SpDMD(gamma=2).gamma == 2
-
-    def test_exact(self):
-        assert SpDMD().exact == True
-
-    def test_abstol(self):
-        assert SpDMD()._abs_tol == 1.0e-6
-        assert SpDMD(abs_tolerance=1.0e10)._abs_tol == 1.0e10
-
-    def test_reltol(self):
-        assert SpDMD()._rel_tol == 1.0e-4
-        assert SpDMD(rel_tolerance=1.0e10)._rel_tol == 1.0e10
-
-    def test_verbose(self):
-        assert SpDMD()._verbose == True
-        assert SpDMD(verbose=False)._verbose == False
-
-    def test_enforce_zero(self):
-        assert SpDMD()._enforce_zero == True
-        assert SpDMD(enforce_zero=False)._enforce_zero == False
-
-    def test_release_memory(self):
-        assert SpDMD()._release_memory == True
-        assert SpDMD(release_memory=False)._release_memory == False
-
-    def test_zero_tolerance(self):
-        assert SpDMD()._zero_absolute_tolerance == 1.0e-12
-        assert SpDMD(
-            zero_absolute_tolerance=1.0e-6)._zero_absolute_tolerance == 1.0e-6
-
-    def test_zero_tolerance_no_zeros(self):
-        zero_amps = (
-            SpDMD(zero_absolute_tolerance=1.0e30, release_memory=False)
             .fit(data)
             ._find_zero_amplitudes()
+            == z
         )
-        assert all(zero_amps)
 
-    def test_zero_tolerance_all_zeros(self):
-        zero_amps = (
-            SpDMD(zero_absolute_tolerance=0, release_memory=False)
+def test_number_nonzero_amplitudes_rho1e4():
+    zeros = np.load("tests/test_datasets/zero_amplitudes_rho1e4.npy")
+
+    for gm, z in zip(gammas, zeros.T):
+        assert all(
+            SpDMD(
+                svd_rank=30,
+                gamma=gm,
+                rho=1.0e4,
+                release_memory=False,
+            )
             .fit(data)
             ._find_zero_amplitudes()
+            == z
         )
-        assert all(np.logical_not(zero_amps))
 
-    def test_release_memory_releases(self):
-        o = SpDMD(release_memory=True).fit(data)
-        assert o._P is None
-        assert o._Plow is None
-        assert o._q is None
 
-        o = SpDMD(release_memory=False).fit(data)
-        assert o._P is not None
-        assert o._Plow is not None
-        assert o._q is not None
+def test_spdmd_amplitudes_rho1():
+    amps = np.load("tests/test_datasets/spdmd_amplitudes_rho1.npy")
 
-    def test_update_lagrangian(self):
-        alpha = np.random.rand(10)
-        beta = np.random.rand(10)
-        lmbd = np.random.rand(10)
-
+    for gm, z in zip(gammas, amps.T):
         np.testing.assert_allclose(
-            SpDMD(rho=0)._update_lagrangian(alpha, beta, lmbd), lmbd
+            SpDMD(
+                svd_rank=30,
+                gamma=gm,
+            )
+            .fit(data)
+            .amplitudes,
+            z,
+            rtol=2,
+            atol=1.e-6
         )
+
+def test_spdmd_amplitudes_rho1e4():
+    amps = np.load("tests/test_datasets/spdmd_amplitudes_rho1e4.npy")
+
+    for gm, z in zip(gammas, amps.T):
         np.testing.assert_allclose(
-            SpDMD()._update_lagrangian(alpha, alpha, lmbd), lmbd
+            SpDMD(svd_rank=30, gamma=gm, rho=1.0e4).fit(data).amplitudes,
+            z,
+            rtol=2,
+            atol=1.e-6
         )
 
-    def test_update_alpha(self):
-        o = SpDMD(release_memory=False).fit(data)
+def test_rho():
+    assert SpDMD().rho == 1
+    assert SpDMD(rho=10).rho == 10
 
-        beta = np.random.rand(len(o.amplitudes))
-        lmbd = np.random.rand(len(o.amplitudes))
+def test_maxiter():
+    assert SpDMD()._max_iterations == 10000
+    assert SpDMD(max_iterations=2)._max_iterations == 2
 
-        uk = beta - lmbd / o.rho
+def test_gamma():
+    assert SpDMD().gamma == 10
+    assert SpDMD(gamma=2).gamma == 2
 
-        rhs = np.linalg.solve(o._Plow, o._q + uk * o.rho / 2)
-        lhs = o._Plow.conj().T
+def test_exact():
+    assert SpDMD().exact == True
 
-        np.testing.assert_allclose(lhs.dot(o._update_alpha(beta, lmbd)), rhs)
+def test_abstol():
+    assert SpDMD()._abs_tol == 1.0e-6
+    assert SpDMD(abs_tolerance=1.0e10)._abs_tol == 1.0e10
 
-    def test_get_bitmask_default(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
-        assert np.all(dmd.modes_activation_bitmask == True)
+def test_reltol():
+    assert SpDMD()._rel_tol == 1.0e-4
+    assert SpDMD(rel_tolerance=1.0e10)._rel_tol == 1.0e10
 
-    def test_set_bitmask(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
+def test_verbose():
+    assert SpDMD()._verbose == True
+    assert SpDMD(verbose=False)._verbose == False
 
-        new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
-        new_bitmask[[0]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_enforce_zero():
+    assert SpDMD()._enforce_zero == True
+    assert SpDMD(enforce_zero=False)._enforce_zero == False
 
-        assert dmd.modes_activation_bitmask[0] == False
-        assert np.all(dmd.modes_activation_bitmask[1:] == True)
+def test_release_memory():
+    assert SpDMD()._release_memory == True
+    assert SpDMD(release_memory=False)._release_memory == False
 
-    def test_not_fitted_get_bitmask_raises(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        with self.assertRaises(RuntimeError):
-            print(dmd.modes_activation_bitmask)
+def test_zero_tolerance():
+    assert SpDMD()._zero_absolute_tolerance == 1.0e-12
+    assert SpDMD(
+        zero_absolute_tolerance=1.0e-6)._zero_absolute_tolerance == 1.0e-6
 
-    def test_not_fitted_set_bitmask_raises(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
+def test_zero_tolerance_no_zeros():
+    zero_amps = (
+        SpDMD(zero_absolute_tolerance=1.0e30, release_memory=False)
+        .fit(data)
+        ._find_zero_amplitudes()
+    )
+    assert all(zero_amps)
 
-    def test_raise_wrong_dtype_bitmask(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
-        with self.assertRaises(RuntimeError):
-            dmd.modes_activation_bitmask = np.full(3, 0.1)
+def test_zero_tolerance_all_zeros():
+    zero_amps = (
+        SpDMD(zero_absolute_tolerance=0, release_memory=False)
+        .fit(data)
+        ._find_zero_amplitudes()
+    )
+    assert all(np.logical_not(zero_amps))
 
-    def test_fitted(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        assert not dmd.fitted
-        dmd.fit(X=data)
-        assert dmd.fitted
+def test_release_memory_releases():
+    o = SpDMD(release_memory=True).fit(data)
+    assert o._P is None
+    assert o._Plow is None
+    assert o._q is None
 
-    def test_bitmask_amplitudes(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
+    o = SpDMD(release_memory=False).fit(data)
+    assert o._P is not None
+    assert o._Plow is not None
+    assert o._q is not None
 
-        old_n_amplitudes = dmd.amplitudes.shape[0]
-        retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
+def test_update_lagrangian():
+    alpha = np.random.rand(10)
+    beta = np.random.rand(10)
+    lmbd = np.random.rand(10)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    np.testing.assert_allclose(
+        SpDMD(rho=0)._update_lagrangian(alpha, beta, lmbd), lmbd
+    )
+    np.testing.assert_allclose(
+        SpDMD()._update_lagrangian(alpha, alpha, lmbd), lmbd
+    )
 
-        assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
-        np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
+def test_update_alpha():
+    o = SpDMD(release_memory=False).fit(data)
 
-    def test_bitmask_eigs(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
+    beta = np.random.rand(len(o.amplitudes))
+    lmbd = np.random.rand(len(o.amplitudes))
 
-        old_n_eigs = dmd.eigs.shape[0]
-        retained_eigs = np.delete(dmd.eigs, [0,-1])
+    uk = beta - lmbd / o.rho
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    rhs = np.linalg.solve(o._Plow, o._q + uk * o.rho / 2)
+    lhs = o._Plow.conj().T
 
-        assert dmd.eigs.shape[0] == old_n_eigs - 2
-        np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
+    np.testing.assert_allclose(lhs.dot(o._update_alpha(beta, lmbd)), rhs)
 
-    def test_bitmask_modes(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
+def test_get_bitmask_default():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
+    assert np.all(dmd.modes_activation_bitmask == True)
 
-        old_n_modes = dmd.modes.shape[1]
-        retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
+def test_set_bitmask():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+    new_bitmask = np.full(len(dmd.amplitudes), True, dtype=bool)
+    new_bitmask[[0]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes.shape[1] == old_n_modes - 2
-        np.testing.assert_almost_equal(dmd.modes, retained_modes)
+    assert dmd.modes_activation_bitmask[0] == False
+    assert np.all(dmd.modes_activation_bitmask[1:] == True)
 
-    def test_reconstructed_data(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
+def test_not_fitted_get_bitmask_raises():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    with raises(RuntimeError):
+        print(dmd.modes_activation_bitmask)
 
-        new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
-        new_bitmask[[0,-1]] = False
-        dmd.modes_activation_bitmask = new_bitmask
+def test_not_fitted_set_bitmask_raises():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, True, dtype=bool)
 
-        dmd.reconstructed_data
-        assert True
+def test_raise_wrong_dtype_bitmask():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
+    with raises(RuntimeError):
+        dmd.modes_activation_bitmask = np.full(3, 0.1)
 
-    def test_getitem_modes(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
-        old_n_modes = dmd.modes.shape[1]
+def test_fitted():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    assert not dmd.fitted
+    dmd.fit(X=data)
+    assert dmd.fitted
 
-        assert dmd[[0,-1]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+def test_bitmask_amplitudes():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
 
-        assert dmd.modes.shape[1] == old_n_modes
+    old_n_amplitudes = dmd.amplitudes.shape[0]
+    retained_amplitudes = np.delete(dmd.amplitudes, [0,-1])
 
-        assert dmd[1::2].modes.shape[1] == old_n_modes // 2
-        np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.amplitudes.shape[0] == old_n_amplitudes - 2
+    np.testing.assert_almost_equal(dmd.amplitudes, retained_amplitudes)
 
-        assert dmd[[1,3]].modes.shape[1] == 2
-        np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+def test_bitmask_eigs():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
 
-        assert dmd.modes.shape[1] == old_n_modes
+    old_n_eigs = dmd.eigs.shape[0]
+    retained_eigs = np.delete(dmd.eigs, [0,-1])
 
-        assert dmd[2].modes.shape[1] == 1
-        np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
 
-        assert dmd.modes.shape[1] == old_n_modes
+    assert dmd.eigs.shape[0] == old_n_eigs - 2
+    np.testing.assert_almost_equal(dmd.eigs, retained_eigs)
 
-    def test_getitem_raises(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
+def test_bitmask_modes():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
 
-        with self.assertRaises(ValueError):
-            dmd[[0,1,1,0,1]]
-        with self.assertRaises(ValueError):
-            dmd[[True, True, False, True]]
-        with self.assertRaises(ValueError):
-            dmd[1.0]
+    old_n_modes = dmd.modes.shape[1]
+    retained_modes = np.delete(dmd.modes, [0,-1], axis=1)
 
-    # this is a test for the correctness of the amplitudes saved in the Proxy
-    # between DMDBase and the modes activation bitmask. if this test fails
-    # you probably need to call allocate_proxy once again after you compute
-    # the final value of the amplitudes
-    def test_correct_amplitudes(self):
-        dmd = SpDMD(release_memory=True, svd_rank=-1)
-        dmd.fit(X=data)
-        np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    assert dmd.modes.shape[1] == old_n_modes - 2
+    np.testing.assert_almost_equal(dmd.modes, retained_modes)
+
+def test_reconstructed_data():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
+
+    new_bitmask = np.full(dmd.amplitudes.shape[0], True, dtype=bool)
+    new_bitmask[[0,-1]] = False
+    dmd.modes_activation_bitmask = new_bitmask
+
+    dmd.reconstructed_data
+    assert True
+
+def test_getitem_modes():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
+    old_n_modes = dmd.modes.shape[1]
+
+    assert dmd[[0,-1]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[0,-1]].modes, dmd.modes[:,[0,-1]])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+    assert dmd[1::2].modes.shape[1] == old_n_modes // 2
+    np.testing.assert_almost_equal(dmd[1::2].modes, dmd.modes[:,1::2])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+    assert dmd[[1,3]].modes.shape[1] == 2
+    np.testing.assert_almost_equal(dmd[[1,3]].modes, dmd.modes[:,[1,3]])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+    assert dmd[2].modes.shape[1] == 1
+    np.testing.assert_almost_equal(np.squeeze(dmd[2].modes), dmd.modes[:,2])
+
+    assert dmd.modes.shape[1] == old_n_modes
+
+def test_getitem_raises():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
+
+    with raises(ValueError):
+        dmd[[0,1,1,0,1]]
+    with raises(ValueError):
+        dmd[[True, True, False, True]]
+    with raises(ValueError):
+        dmd[1.0]
+
+# this is a test for the correctness of the amplitudes saved in the Proxy
+# between DMDBase and the modes activation bitmask. if this test fails
+# you probably need to call allocate_proxy once again after you compute
+# the final value of the amplitudes
+def test_correct_amplitudes():
+    dmd = SpDMD(release_memory=True, svd_rank=-1)
+    dmd.fit(X=data)
+    np.testing.assert_array_almost_equal(dmd.amplitudes, dmd._b)


### PR DESCRIPTION
In this commit I converted all the remaining ´unittest´ under `tests/` to pytest's interface. Now we don't have dependencies on `unittest` anymore.