### PR TITLE
Update old docs format for `DMD.predict` method

### DIFF
--- a/pydmd/dmd.py
+++ b/pydmd/dmd.py
@@ -76,18 +76,12 @@ class DMD(DMDBase):
         return self
 
     def predict(self, X):
-        """Predict the output Y given the input X using the fitted DMD model.
+        """
+        Predict the output Y given the input X using the fitted DMD model.
 
-        Parameters
-        ----------
-        X : numpy array
-            Input data.
-
-        Returns
-        -------
-        Y : numpy array
-            Predicted output.
-
+        :param numpy.ndarray X: the input vector.
+        :return: one time-step ahead predicted output.
+        :rtype: numpy.ndarray
         """
         return np.linalg.multi_dot(
             [self.modes, np.diag(self.eigs), pinv(self.modes), X]


### PR DESCRIPTION
Updating the docs for `DMD.predict` since we forgot to adapt it to the format of docs for the other methods in PyDMD.