### PR TITLE
Adding HAVOK to PyDMD

### DIFF
--- a/pydmd/__init__.py
+++ b/pydmd/__init__.py
@@ -2,7 +2,7 @@
 PyDMD init
 """
 __all__ = ['dmdbase', 'dmd', 'fbdmd', 'mrdmd', 'cdmd', 'hodmd', 'dmdc',
-           'optdmd', 'hankeldmd']
+           'optdmd', 'hankeldmd', 'rdmd', 'havok']
 
 
 from .meta import *
@@ -20,3 +20,4 @@ from .paramdmd import ParametricDMD
 from .dmd_modes_tuner import ModesTuner
 from .subspacedmd import SubspaceDMD
 from .rdmd import RDMD
+from .havok import HAVOK

--- a/pydmd/hankeldmd.py
+++ b/pydmd/hankeldmd.py
@@ -69,6 +69,7 @@ class HankelDMD(DMDBase):
         d=1,
         sorted_eigs=False,
         reconstruction_method="first",
+        tikhonov_regularization=None,
     ):
         super().__init__(
             svd_rank=svd_rank,
@@ -103,6 +104,7 @@ class HankelDMD(DMDBase):
             rescale_mode=rescale_mode,
             forward_backward=forward_backward,
             sorted_eigs=sorted_eigs,
+            tikhonov_regularization=tikhonov_regularization,
         )
 
     @property

--- a/pydmd/havok.py
+++ b/pydmd/havok.py
@@ -139,9 +139,8 @@ class HAVOK(HankelDMD):
             np.diag(self._svd_amps[:-1]),
             reconstructed_v.conj().T
         ])
-        reconstructed_x = self._dehankel(reconstructed_hankel_matrix)
 
-        return reconstructed_x
+        return self._dehankel(reconstructed_hankel_matrix)
 
     def fit(self, x, dt):
         """
@@ -152,7 +151,7 @@ class HAVOK(HankelDMD):
         self._snapshots = self._snapshots.squeeze()
 
         # Check that input data is a 1D time-series
-        if np.ndim(self._snapshots) != 1:
+        if self._snapshots.ndim > 1:
             raise ValueError("Input data must be a 1-D time series.")
 
         # Get number of data points
@@ -165,9 +164,7 @@ Expected at least d."""
             raise ValueError(msg.format(self._d))
 
         # Compute hankel matrix for the input data
-        self._hankel_matrix = self._pseudo_hankel_matrix(
-            self._snapshots.reshape(1, -1)
-        )
+        self._hankel_matrix = self._pseudo_hankel_matrix(self._snapshots[None])
 
         # Take SVD of the hankel matrix
         # Save the resulting U, s, and V for future reconstructions
@@ -192,7 +189,7 @@ Expected at least d."""
 
         # Save A matrix and B vector
         self._A = regression_model_continuous[:-1, :-1]
-        self._B = regression_model_continuous[:-1, -1].reshape(-1, 1)
+        self._B = regression_model_continuous[:-1, -1, None]
 
         # Set timesteps
         self._set_initial_time_dictionary(

--- a/pydmd/havok.py
+++ b/pydmd/havok.py
@@ -35,7 +35,7 @@ class HAVOK(HankelDMD):
             opt=opt,
             rescale_mode=rescale_mode,
             forward_backward=forward_backward,
-            sorted_eigs=sorted_eigs, 
+            sorted_eigs=sorted_eigs,
             tikhonov_regularization=tikhonov_regularization,
             d=d,
         )
@@ -52,6 +52,8 @@ class HAVOK(HankelDMD):
         :return: matrix containing the linear time-delay embeddings.
         :rtype: numpy.ndarray
         """
+        if self._embeddings is None:
+            raise RuntimeError("fit() not called")
         return self._embeddings[:,:-1]
 
     @property
@@ -62,6 +64,8 @@ class HAVOK(HankelDMD):
         :return: array containing the chaotic forcing term.
         :rtype: numpy.ndarray
         """
+        if self._embeddings is None:
+            raise RuntimeError("fit() not called")
         return self._embeddings[:,-1]
 
     @property
@@ -73,6 +77,8 @@ class HAVOK(HankelDMD):
         :return: linear dynamics matrix A.
         :rtype: numpy.ndarray
         """
+        if self._A is None:
+            raise RuntimeError("fit() not called")
         return self._A
 
     @property
@@ -84,6 +90,8 @@ class HAVOK(HankelDMD):
         :return: forcing dynamics vector B.
         :rtype: numpy.ndarray
         """
+        if self._B is None:
+            raise RuntimeError("fit() not called")
         return self._B
 
     def _dehankel(self, X):
@@ -100,7 +108,7 @@ class HAVOK(HankelDMD):
 
     @property
     def reconstructed_data(self):
-        # Build a continuous-time system of the following form, where 
+        # Build a continuous-time system of the following form, where
         # x, u, and y represent the states, inputs, and outputs respectively.
         #
         # dx/dt = Ax + Bu
@@ -182,7 +190,7 @@ Expected at least d."""
             regression_model_discrete - np.eye(self._r)
         ) / dt
 
-        # Save A matrix and B vector 
+        # Save A matrix and B vector
         self._A = regression_model_continuous[:-1, :-1]
         self._B = regression_model_continuous[:-1, -1].reshape(-1, 1)
 

--- a/pydmd/havok.py
+++ b/pydmd/havok.py
@@ -1,0 +1,194 @@
+"""
+Derived module from hankeldmd.py for HAVOK.
+
+Reference:
+- S. L. Brunton, B. W. Brunton, J. L. Proctor,Eurika Kaiser, and J. N. Kutz.
+Chaos as an intermittently forced linear system.
+Nature Communications, 8, 2017.
+"""
+
+import numpy as np
+from scipy import signal
+from .hankeldmd import HankelDMD
+from .utils import compute_svd
+
+class HAVOK(HankelDMD):
+    """
+    Hankel alternative view of Koopman (HAVOK) analysis
+    """
+    def __init__(
+        self,
+        svd_rank=0,
+        tlsq_rank=0,
+        exact=False,
+        opt=False,
+        rescale_mode=None,
+        forward_backward=False,
+        sorted_eigs=False,
+        tikhonov_regularization=None,
+        d=1,
+    ):
+        super().__init__(
+            svd_rank=svd_rank,
+            tlsq_rank=tlsq_rank,
+            exact=exact,
+            opt=opt,
+            rescale_mode=rescale_mode,
+            forward_backward=forward_backward,
+            sorted_eigs=sorted_eigs, 
+            tikhonov_regularization=tikhonov_regularization,
+            d=d,
+        )
+        self._embeddings = None
+        self._A = None
+        self._B = None
+
+    @property
+    def linear_embeddings(self):
+        """
+        Get the time-delay embeddings of the data that are governed by linear
+        dynamics. Emeddings are stored as columns of the returned matrix.
+
+        :return: matrix containing the linear time-delay embeddings.
+        :rtype: numpy.ndarray
+        """
+        return self._embeddings[:,:-1]
+
+    @property
+    def forcing_input(self):
+        """
+        Get the time-delay embedding that forces the linear embeddings.
+
+        :return: array containing the chaotic forcing term.
+        :rtype: numpy.ndarray
+        """
+        return self._embeddings[:,-1]
+
+    @property
+    def A(self):
+        """
+        Get the matrix A in the relationship dV/dt = AV + Bu, where V denotes
+        the linear embeddings and u denotes the forcing input.
+
+        :return: linear dynamics matrix A.
+        :rtype: numpy.ndarray
+        """
+        return self._A
+
+    @property
+    def B(self):
+        """
+        Get the vector B in the relationship dV/dt = AV + Bu, where V denotes
+        the linear embeddings and u denotes the forcing input.
+
+        :return: forcing dynamics vector B.
+        :rtype: numpy.ndarray
+        """
+        return self._B
+
+    def _dehankel(self, X):
+        """
+        Given a hankel matrix X as a 2-D numpy.ndarray,
+        returns the data as a 1-D time-series.
+        """
+        return np.concatenate((X[0, :], X[1:, -1]))
+
+    def reconstructions_of_timeindex(self, timeindex=None):
+        raise NotImplementedError(
+            "This function is not compatible with HAVOK."
+        )
+
+    @property
+    def reconstructed_data(self):
+        # Build a continuous-time system of the following form, where 
+        # x, u, and y represent the states, inputs, and outputs respectively.
+        #
+        # dx/dt = Ax + Bu
+        # y = Cx + Du
+        #
+        # Note that we define the output y to be the state x.
+        havok_system = signal.StateSpace(
+            self.A, self.B, np.eye(self._r-1), 0*self.B
+        )
+
+        # Using the system defined above, compute the output of the system,
+        # where the system input is the forcing input, the times of forcing
+        # are given by self.dmd_timesteps, and the initial state values are
+        # given by the initial values of the linear time-delay embeddings.
+        # This yields a reconstruction of V from the SVD of the hankel matrix.
+        reconstructed_v = signal.lsim(
+            havok_system,
+            U=self.forcing_input,
+            T=self.dmd_timesteps[:len(self.forcing_input)],
+            X0=self.linear_embeddings[0, :]
+        )[1]
+
+        # Compute a reconstruction of the original data x by first recomputing
+        # the hankel matrix with the reconstructed V matrix and then recovering
+        # a 1-D time-series from the computed hankel matrix.
+        reconstructed_hankel_matrix = np.linalg.multi_dot([
+            self._svd_modes[:, :-1],
+            np.diag(self._svd_amps[:-1]),
+            reconstructed_v.conj().T
+        ])
+        reconstructed_x = self._dehankel(reconstructed_hankel_matrix)
+
+        return reconstructed_x
+
+    def fit(self, x, dt):
+        """
+        Perform HAVOK analysis on 1-D time-series data x given the size of
+        the time step dt separating the observations in x.
+        """
+        self._snapshots, self._snapshots_shape = self._col_major_2darray(x)
+        self._snapshots = self._snapshots.squeeze()
+
+        # Check that input data is a 1D time-series
+        if np.ndim(self._snapshots) != 1:
+            raise ValueError("Input data must be a 1-D time series.")
+
+        # Get number of data points
+        n_samples = len(self._snapshots)
+
+        # Check that the input time-series contains enough observations
+        if n_samples < self._d:
+            msg = """The number of snapshots provided is not enough for d={}.
+Expected at least d."""
+            raise ValueError(msg.format(self._d))
+
+        # Compute hankel matrix for the input data
+        self._hankel_matrix = self._pseudo_hankel_matrix(
+            self._snapshots.reshape(1, -1)
+        )
+
+        # Take SVD of the hankel matrix
+        # Save the resulting U, s, and V for future reconstructions
+        self._svd_modes, self._svd_amps, self._embeddings = compute_svd(
+            self._hankel_matrix, self.svd_rank
+        )
+        self._r = len(self._svd_amps)
+
+        # Perform DMD on the time-delay embeddings
+        self._sub_dmd.fit(self._embeddings.T)
+
+        # Compute the full (discrete-time) system matrix
+        w, e = self._sub_dmd.modes, self._sub_dmd.eigs
+        regression_model_discrete = np.linalg.multi_dot(
+            [w, np.diag(e), np.linalg.pinv(w)]
+        )
+
+        # Roughly approximate the continuous-time system matrix
+        regression_model_continuous = (
+            regression_model_discrete - np.eye(self._r)
+        ) / dt
+
+        # Save A matrix and B vector 
+        self._A = regression_model_continuous[:-1, :-1]
+        self._B = regression_model_continuous[:-1, -1].reshape(-1, 1)
+
+        # Set timesteps
+        self._set_initial_time_dictionary(
+            {"t0": 0, "tend": (n_samples - 1) * dt, "dt": dt}
+        )
+
+        return self

--- a/pydmd/havok.py
+++ b/pydmd/havok.py
@@ -26,7 +26,7 @@ class HAVOK(HankelDMD):
         forward_backward=False,
         sorted_eigs=False,
         tikhonov_regularization=None,
-        d=1,
+        d=10,
     ):
         super().__init__(
             svd_rank=svd_rank,
@@ -42,6 +42,7 @@ class HAVOK(HankelDMD):
         self._embeddings = None
         self._A = None
         self._B = None
+        self._r = None
 
     @property
     def linear_embeddings(self):
@@ -93,6 +94,16 @@ class HAVOK(HankelDMD):
         if self._B is None:
             raise RuntimeError("fit() not called")
         return self._B
+
+    @property
+    def r(self):
+        """
+        Number of time-delay embeddings utilized by the HAVOK model.
+        Note: d is the same as svd_rank if svd_rank is a positive integer.
+        """
+        if self._r is None:
+            raise RuntimeError("fit() not called")
+        return self._r
 
     def _dehankel(self, X):
         """
@@ -164,14 +175,22 @@ Expected at least d."""
             raise ValueError(msg.format(self._d))
 
         # Compute hankel matrix for the input data
-        self._hankel_matrix = self._pseudo_hankel_matrix(self._snapshots[None])
+        hankel_matrix = self._pseudo_hankel_matrix(self._snapshots[None])
 
         # Take SVD of the hankel matrix
         # Save the resulting U, s, and V for future reconstructions
         self._svd_modes, self._svd_amps, self._embeddings = compute_svd(
-            self._hankel_matrix, self.svd_rank
+            hankel_matrix, self.svd_rank
         )
+
+        # Record the number of time-delay embeddings being used.
+        # Throw an error if less than 2 embeddings are being used.
         self._r = len(self._svd_amps)
+        if self._r < 2:
+            msg = """HAVOK model is attempting to use r = {} embeddings when r
+should be at least 2. Try increasing the number of delays d and/or providing a
+positive integer argument for svd_rank."""
+            raise RuntimeError(msg.format(self._r))
 
         # Perform DMD on the time-delay embeddings
         self._sub_dmd.fit(self._embeddings.T)

--- a/tests/test_havok.py
+++ b/tests/test_havok.py
@@ -1,0 +1,135 @@
+from pytest import raises
+from pydmd import HAVOK
+from scipy.integrate import ode
+import numpy as np
+
+def lorenz_system(t, state, par):
+    """
+    Defines the system of differential equations y'(t) = f(t, y, params)
+    """
+    x, y, z = state
+    sigma, rho, beta = par
+    x_dot = sigma * (y - x)
+    y_dot = (x * (rho - z)) - y
+    z_dot = (x * y) - (beta * z)
+    return np.array((x_dot, y_dot, z_dot))
+
+def generate_lorenz_data(t):
+    """
+    Given a time vector t = t1, t2, ..., evaluates and returns the snapshots
+    of the Lorenz system as columns of the matrix X via explicit Runge-Kutta.
+    """
+    # Chaotic Lorenz parameters
+    sigma, rho, beta = 10, 28, 8/3
+
+    # Initial condition
+    initial = np.array((-8, 8, 27))
+
+    # Generate Lorenz data
+    X = np.empty((3, len(t)))
+    X[:, 0] = initial
+    r = ode(lorenz_system).set_integrator("dopri5")
+    r.set_initial_value(initial, t[0])
+    r.set_f_params((sigma, rho, beta))
+    for i, ti in enumerate(t):
+        if i == 0:
+            continue
+        r.integrate(ti)
+        X[:, i] = r.y
+
+    return X
+
+# Generate chaotic Lorenz System data
+dt = 0.001
+t = np.arange(0, 100, dt)
+lorenz_xyz = generate_lorenz_data(t)
+lorenz_x = lorenz_xyz[0]
+
+def test_shape():
+    """
+    Using the default HAVOK parameters, checks that the shapes of
+    linear_embeddings, forcing_input, A, and B are accurate.
+    """
+    havok = HAVOK()
+    havok.fit(lorenz_x, dt)
+    assert havok.linear_embeddings.shape == (len(t)-havok.d+1, havok.r-1)
+    assert havok.forcing_input.shape == (len(t)-havok.d+1,)
+    assert havok.A.shape == (havok.r-1, havok.r-1)
+    assert havok.B.shape == (havok.r-1, 1)
+
+def test_error_fitted():
+    """
+    Ensure that attempting to get the attributes linear_embeddings,
+    forcing_input, A, B, or r results in a RuntimeError if fit()
+    has not yet been called.
+    """
+    havok = HAVOK()
+    with raises(RuntimeError):
+        _ = havok.linear_embeddings
+    with raises(RuntimeError):
+        _ = havok.forcing_input
+    with raises(RuntimeError):
+        _ = havok.A
+    with raises(RuntimeError):
+        _ = havok.B
+    with raises(RuntimeError):
+        _ = havok.r
+
+def test_error_1d():
+    """
+    Ensure that the fit function will reject data that isn't one-dimensional.
+    """
+    havok = HAVOK()
+    with raises(ValueError):
+        havok.fit(lorenz_xyz, dt)
+
+def test_error_reconstructions_of_timeindex():
+    """
+    Ensure that calling reconstructions_of_timeindex results in an error.
+    """
+    havok = HAVOK()
+    with raises(NotImplementedError):
+        havok.reconstructions_of_timeindex()
+
+def test_error_small_r():
+    """
+    Ensure that a runtime error is thrown if r is too small.
+    """
+    havok = HAVOK(d=1)
+    with raises(RuntimeError):
+        havok.fit(lorenz_x, dt)
+
+def test_r():
+    """
+    Ensure the accuracy of the r property in the following situations:
+    """
+    # If no svd truncation, r is the min of the dimensions of the hankel matrix
+    havok = HAVOK(svd_rank=-1)
+    havok.fit(lorenz_x, dt)
+    assert havok.r == min(havok.d, len(t)-havok.d+1)
+
+    # Test the above case, but for a larger d value
+    havok = HAVOK(svd_rank=-1, d=500)
+    havok.fit(lorenz_x, dt)
+    assert havok.r == min(havok.d, len(t)-havok.d+1)
+
+    # Test the above case, but for an even larger d value
+    havok = HAVOK(svd_rank=-1, d=len(t)-20)
+    havok.fit(lorenz_x, dt)
+    assert havok.r == min(havok.d, len(t)-havok.d+1)
+
+    # If given a positive integer svd truncation, r should equal svd_rank
+    havok = HAVOK(svd_rank=3)
+    havok.fit(lorenz_x, dt)
+    assert havok.r == havok.svd_rank
+
+def test_reconstruction():
+    """
+    Test the accuracy of the HAVOK reconstruction. Note that the parameters
+    used here have been successful in reconstructing the Lorenz System.
+    """
+    havok = HAVOK(svd_rank=15, d=100)
+    havok.fit(lorenz_x, dt)
+    error = lorenz_x - havok.reconstructed_data.real
+    error_norm = np.linalg.norm(error) / np.linalg.norm(lorenz_x)
+    assert error_norm < 0.2


### PR DESCRIPTION
Hello again to everyone on the PyDMD team!

I am here to propose the next potential addition to the PyDMD family: the Hankel Alternative View of Koopman (HAVOK) analysis! In case anyone is interested, the article deriving and describing the method can be found here: https://www.nature.com/articles/s41467-017-00030-8

HAVOK is a method specifically tailored for modeling one-dimensional time-series datasets that exhibit chaos. In short, the algorithm can be broken down into the following steps:

1) Compute a hankel matrix $H$ from the input time-series.
2) Compute the SVD of the hankel matrix $H = U\Sigma V^*$.
3) Apply DMD to $V^T$ and obtain the continuous-time DMD operator $A_c$ in $\dot{V}^T = A_c V^T$.
4) Define $A$ as the matrix $A_c$ but excluing the last row and column. Define $B$ as the last column of $A_c$, but excluding the last entry.
5) We may then model our data via the relationship $\dot{v} = Av + Bv_r$, where $V = [v_1 \quad \dots \quad v_r]$ and $v = [v_1 \quad \dots \quad v_{r-1}]^T$.

Given the structure of the HAVOK analysis, I have made the following implementation choices:
- The `HAVOK` class is a child of the `HankelDMD` class due to their shared usage of hankel matrices. Note that the key differences between the two methods are (1) HAVOK applies DMD to the $V$ matrix from the SVD of $H$ while Hankel DMD applies DMD to $H$, and (2) HAVOK utilizes a forcing term in order to reconstruct data, while Hankel DMD does not.
- In order to utilize currently-existing DMD modules, I compute the continuous-time operator $A_c$ by first using DMD to compute the discrete-time operator $A_d$ in $V_2^T = A_d V_1^T$. I then utilize the approximation $A_c \approx (A_d - I) / \Delta t$. There are most certainly better/more accurate methods of computing $A_c$, but I figured this rough approximation should suffice for now.
- I'm currently using `scipy.signal` in order to compute the HAVOK reconstructions (since this is how reconstructions are computed in the original HAVOK paper, and the code is quite concise), but I could also envision this being implemented via the `DMDc` module somehow... I'm happy to keep the reconstruction code as is, but if reusing code from `DMDc` has the potential to be stylistically better, I'd be happy to give the implementation a shot!
- One other thing, I've added a `tikhonov_regularization` input parameter to `HankelDMD` so that it may now be used by both `HankelDMD` and `HAVOK`. Let me know if this parameter was omitted from `HankelDMD` for any particular reason so that I can restore `HankelDMD` to its original form! :)

Thank you all again for your diligence and support with these new modules. 😄 

I'm also open to any feedback, comments, questions, or concerns that may arise with this module. :)