### PR TITLE
Tests cleanup, unhide hidden tests

### DIFF
--- a/tests/test_cdmd.py
+++ b/tests/test_cdmd.py
@@ -1,9 +1,11 @@
+import os
 from builtins import range
-from pytest import raises
-from pydmd.cdmd import CDMD
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
+from pytest import raises
+
+from pydmd.cdmd import CDMD
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -351,7 +353,7 @@ def test_getitem_raises():
     with raises(ValueError):
         dmd[1.0]
 
-def test_reconstructed_data():
+def test_reconstructed_data_with_bitmask():
     dmd = CDMD(compression_matrix='normal')
     dmd.fit(X=sample_data)
 

--- a/tests/test_dmd.py
+++ b/tests/test_dmd.py
@@ -1,9 +1,11 @@
+import os
 from builtins import range
-from pydmd.dmd import DMD
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
 from pytest import raises
+
+from pydmd.dmd import DMD
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -654,7 +656,7 @@ def test_second_fit():
     with raises(AssertionError):
         np.testing.assert_allclose(modes, modes2)
 
-def test_reconstructed_data():
+def test_reconstructed_data_with_bitmask():
     dmd = DMD(svd_rank=10)
     dmd.fit(X=sample_data)
 

--- a/tests/test_dmd_modes_tuner.py
+++ b/tests/test_dmd_modes_tuner.py
@@ -1,11 +1,14 @@
-from pytest import raises
-import numpy as np
 from copy import deepcopy
 
-from pydmd import DMD, CDMD, DMD, DMDBase, DMDc, FbDMD, HankelDMD, HODMD, MrDMD, OptDMD, ParametricDMD, SpDMD
-from pydmd.dmd_modes_tuner import select_modes, stabilize_modes, ModesSelectors, ModesTuner, selectors
-from ezyrb import POD, RBF
+import numpy as np
 import pytest
+from ezyrb import POD, RBF
+from pytest import raises, param
+
+from pydmd import (CDMD, DMD, HODMD, DMDBase, DMDc, FbDMD, HankelDMD, MrDMD,
+                   OptDMD, ParametricDMD, SpDMD)
+from pydmd.dmd_modes_tuner import (ModesSelectors, ModesTuner, select_modes,
+                                   selectors, stabilize_modes)
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -559,8 +562,17 @@ def test_modes_tuner_selectors():
     assert selectors['stable_modes'] == ModesSelectors.stable_modes
     assert selectors['integral_contribution'] == ModesSelectors.integral_contribution
 
-@pytest.mark.parametrize("dmd", [CDMD(svd_rank=-1), DMD(svd_rank=-1), DMDc(svd_rank=-1), FbDMD(svd_rank=-1),
-    HankelDMD(svd_rank=-1, d=3), HODMD(svd_rank=-1, d=3)])
+@pytest.mark.parametrize(
+    "dmd",
+    [
+        param(CDMD(svd_rank=-1), id="CDMD"),
+        param(DMD(svd_rank=-1), id="DMD"),
+        param(DMDc(svd_rank=-1), id="DMDc"),
+        param(FbDMD(svd_rank=-1), id="FbDMD"),
+        param(HankelDMD(svd_rank=-1, d=3), id="HankelDMD"),
+        param(HODMD(svd_rank=-1, d=3), id="HODMD"),
+    ],
+)
 def test_modes_selector_all_dmd_types(dmd):
     print('--------------------------- {} ---------------------------'.format(type(dmd)))
     if isinstance(dmd, ParametricDMD):

--- a/tests/test_dmdbase.py
+++ b/tests/test_dmdbase.py
@@ -1,8 +1,9 @@
-from pydmd.dmdbase import DMDBase
-from pydmd import DMD
 import matplotlib.pyplot as plt
 import numpy as np
 from pytest import raises
+
+from pydmd import DMD
+from pydmd.dmdbase import DMDBase
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where

--- a/tests/test_dmdc.py
+++ b/tests/test_dmdc.py
@@ -1,10 +1,12 @@
 from __future__ import division
-from past.utils import old_div
-from pydmd import DMDc
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy
+from past.utils import old_div
 from pytest import raises
+
+from pydmd import DMDc
 
 
 def create_system_with_B():

--- a/tests/test_dmdoperator.py
+++ b/tests/test_dmdoperator.py
@@ -1,13 +1,12 @@
-from builtins import range
-import numpy as np
 import os
+from builtins import range
 
+import matplotlib.pyplot as plt
+import numpy as np
 from pytest import raises
 
 from pydmd.dmdoperator import DMDOperator
 from pydmd.utils import compute_tlsq
-
-import matplotlib.pyplot as plt
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where

--- a/tests/test_fbdmd.py
+++ b/tests/test_fbdmd.py
@@ -1,8 +1,10 @@
 from builtins import range
-from pydmd.fbdmd import FbDMD
+
 import matplotlib.pyplot as plt
 import numpy as np
 from pytest import raises
+
+from pydmd.fbdmd import FbDMD
 
 
 def create_noisy_data():
@@ -169,7 +171,7 @@ def test_bitmask_modes():
     assert dmd.modes.shape[1] == old_n_modes - 2
     np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-def test_reconstructed_data():
+def test_reconstructed_data_with_bitmask():
     dmd = FbDMD(svd_rank=-1)
     dmd.fit(X=sample_data)
 

--- a/tests/test_hankeldmd.py
+++ b/tests/test_hankeldmd.py
@@ -544,7 +544,7 @@ def test_bitmask_modes():
     assert dmd.modes.shape[1] == old_n_modes - 2
     np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-def test_reconstructed_data():
+def test_reconstructed_data_with_bitmask():
     dmd = HankelDMD(svd_rank=-1, d=5)
     dmd.fit(X=sample_data)
 

--- a/tests/test_havok.py
+++ b/tests/test_havok.py
@@ -1,7 +1,9 @@
-from pytest import raises
-from pydmd import HAVOK
-from scipy.integrate import ode
 import numpy as np
+from pytest import raises
+from scipy.integrate import ode
+
+from pydmd import HAVOK
+
 
 def lorenz_system(t, state, par):
     """

--- a/tests/test_hodmd.py
+++ b/tests/test_hodmd.py
@@ -1,9 +1,11 @@
+import os
 from builtins import range
-from pytest import raises
-from pydmd.hodmd import HODMD
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
+from pytest import raises
+
+from pydmd.hodmd import HODMD
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -424,7 +426,7 @@ def test_bitmask_modes():
     assert dmd.modes.shape[1] == old_n_modes - 2
     np.testing.assert_almost_equal(dmd.modes, retained_modes)
 
-def test_reconstructed_data():
+def test_reconstructed_data_with_bitmask():
     dmd = HODMD(svd_rank=-1, d=5)
     dmd.fit(X=sample_data)
 

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -1,10 +1,13 @@
 from __future__ import division
-from past.utils import old_div
-from pytest import raises
-from pydmd.mrdmd import MrDMD
-from pydmd import DMD, FbDMD
+
 import matplotlib.pyplot as plt
 import numpy as np
+from past.utils import old_div
+from pytest import raises
+
+from pydmd import DMD, FbDMD
+from pydmd.mrdmd import MrDMD
+
 
 def create_data(t_size=1600):
     x = np.linspace(-10, 10, 80)
@@ -302,6 +305,7 @@ def test_consistency():
 
 def test_consistency2():
     import sys
+
     import numpy
     numpy.set_printoptions(threshold=sys.maxsize)
 

--- a/tests/test_optdmd.py
+++ b/tests/test_optdmd.py
@@ -1,9 +1,11 @@
+import os
 from builtins import range
-from pytest import raises
-from pydmd.optdmd import OptDMD
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
+from pytest import raises
+
+from pydmd.optdmd import OptDMD
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where

--- a/tests/test_paramdmd.py
+++ b/tests/test_paramdmd.py
@@ -1,10 +1,12 @@
+import os
+
+import numpy as np
+from ezyrb import POD, RBF
 from pytest import raises
+
 from pydmd import DMD, ParametricDMD
 from pydmd.dmdbase import DMDTimeDict
 from pydmd.paramdmd import back_roll_shape, roll_shape
-from ezyrb import POD, RBF
-import numpy as np
-import os
 
 testdir = 'tests/test_datasets/param_dmd/'
 

--- a/tests/test_rdmd.py
+++ b/tests/test_rdmd.py
@@ -1,9 +1,11 @@
+import os
 from builtins import range
-from pytest import raises
-from pydmd.rdmd import RDMD
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
+from pytest import raises
+
+from pydmd.rdmd import RDMD
 
 # 15 snapshot with 400 data. The matrix is 400x15 and it contains
 # the following data: f1 + f2 where
@@ -322,7 +324,7 @@ def test_getitem_raises():
     with raises(ValueError):
         dmd[1.0]
 
-def test_reconstructed_data():
+def test_reconstructed_data_with_bitmask():
     dmd = RDMD()
     dmd.fit(X=sample_data)
 

--- a/tests/test_spdmd.py
+++ b/tests/test_spdmd.py
@@ -1,7 +1,8 @@
-from pydmd import SpDMD, DMD
-import scipy.io
 import numpy as np
+import scipy.io
 from pytest import raises
+
+from pydmd import DMD, SpDMD
 
 data = np.load("tests/test_datasets/heat_90.npy")
 gammas = [1.0e-1, 0.5, 2, 5, 10, 20, 40, 50, 100]

--- a/tests/test_subspacedmd.py
+++ b/tests/test_subspacedmd.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from pydmd import SubspaceDMD
 from pydmd.subspacedmd import SubspaceDMDOperator, reducedsvd
-import numpy as np
 
 
 def test_smoke():


### PR DESCRIPTION
In this PR I cleaned a little bit import statements in`test/`, and changed name to duplicate test cases called `test_reconstructed_data`. The first occurrence (no bitmask) would never appear in the test suite since it was overridden.