### PR TITLE
Fix CI workflow name. Show appropriate badge in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Coverage Deploy to Codacy"
+name: "CI"
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
     <a href="https://badge.fury.io/py/pydmd"  target="_blank">
         <img alt="PyPI version" src="https://badge.fury.io/py/pydmd.svg">
     </a>
-    <a href="https://github.com/mathLab/PyDMD/actions/workflows/testing_pr.yml" target="_blank">
-        <img alt="Build Status" src="https://github.com/mathLab/PyDMD/actions/workflows/testing_pr.yml/badge.svg">
+    <a href="https://github.com/mathLab/PyDMD/actions/workflows/ci.yml" target="_blank">
+        <img alt="Build Status" src="https://github.com/mathLab/PyDMD/actions/workflows/ci.yml/badge.svg">
     </a>
     <a href="https://www.codacy.com/gh/mathLab/PyDMD/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=mathLab/PyDMD&amp;utm_campaign=Badge_Coverage">
       <img src="https://app.codacy.com/project/badge/Coverage/c36adbea2e4a44eb8c0e4505b75e8245"/>


### PR DESCRIPTION
At the moment we're displaying the wrong workflow result in PyDMD README. We should show the badge related to `.github/workflows/ci.yml` instead.