### PR TITLE
Added compute_A parameter to BOPDMD

### DIFF
--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -639,16 +639,17 @@ class BOPDMDOperator(DMDOperator):
         self._modes = np.mean(all_w, axis=0)
         self._eigenvalues = np.mean(all_e, axis=0)
 
-        # Compute Atilde and A using the average optimized dmd results.
+        # Compute Atilde using the average optimized dmd results.
         w_proj = self._proj_basis.conj().T.dot(self._modes)
         self._Atilde = np.linalg.multi_dot(
             [w_proj, np.diag(self._eigenvalues), np.linalg.pinv(w_proj)]
         )
+        # Compute A if requested.
         if self._compute_A:
             self._A = np.linalg.multi_dot(
                 [self._modes,
-                np.diag(self._eigenvalues),
-                np.linalg.pinv(self._modes)]
+                 np.diag(self._eigenvalues),
+                 np.linalg.pinv(self._modes)]
             )
 
         # Compute and save the standard deviation of the optimized dmd results.

--- a/tests/test_bopdmd.py
+++ b/tests/test_bopdmd.py
@@ -60,7 +60,7 @@ def test_truncation_shape():
     Tests that, when given a positive integer rank truncation, the shape of the
     modes, eigenvalues, amplitudes, Atilde operator, and A matrix are accurate.
     """
-    bopdmd = BOPDMD(svd_rank=2)
+    bopdmd = BOPDMD(svd_rank=2, compute_A=True)
     bopdmd.fit(Z, t)
     assert bopdmd.modes.shape[1] == 2
     assert len(bopdmd.eigs) == 2
@@ -106,23 +106,23 @@ def test_A():
     - standard optimized dmd, fit full data
     - optimized dmd with bagging
     """
-    bopdmd = BOPDMD()
+    bopdmd = BOPDMD(compute_A=True)
     bopdmd.fit(Z, t)
     np.testing.assert_allclose(bopdmd.A, expected_A)
 
-    bopdmd = BOPDMD()
+    bopdmd = BOPDMD(compute_A=True)
     bopdmd.fit(Z_uneven, t_uneven)
     np.testing.assert_allclose(bopdmd.A, expected_A)
 
-    bopdmd = BOPDMD(svd_rank=2)
+    bopdmd = BOPDMD(svd_rank=2, compute_A=True)
     bopdmd.fit(Z, t)
     np.testing.assert_allclose(bopdmd.A, expected_A)
 
-    bopdmd = BOPDMD(use_proj=False)
+    bopdmd = BOPDMD(compute_A=True, use_proj=False)
     bopdmd.fit(Z, t)
     np.testing.assert_allclose(bopdmd.A, expected_A)
 
-    bopdmd = BOPDMD(num_trials=100, trial_size=0.2)
+    bopdmd = BOPDMD(compute_A=True, num_trials=100, trial_size=0.2)
     bopdmd.fit(Z, t)
     np.testing.assert_allclose(bopdmd.A, expected_A)
 

--- a/tests/test_bopdmd.py
+++ b/tests/test_bopdmd.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.integrate import ode
+from pytest import raises
 from pydmd.bopdmd import BOPDMD
 
 def f(t, y):
@@ -161,3 +162,22 @@ def test_forecast():
     bopdmd = BOPDMD(num_trials=100, trial_size=0.2)
     bopdmd.fit(Z, t)
     np.testing.assert_allclose(bopdmd.forecast(t_long)[0], Z_long, rtol=1e-4)
+
+def test_compute_A():
+    """
+    Tests that the BOPDMD module appropriately calculates or doesn't calculate
+    A depending on the compute_A flag. Also tests that atilde, the dmd modes,
+    and the dmd eigenvalues are not effected by the compute_A flag.
+    """
+    bopdmd_with_A = BOPDMD(compute_A=True)
+    bopdmd_no_A = BOPDMD(compute_A=False)
+    bopdmd_with_A.fit(Z, t)
+    bopdmd_no_A.fit(Z, t)
+
+    np.testing.assert_allclose(bopdmd_with_A.A, expected_A)
+    with raises(ValueError):
+        print(bopdmd_no_A.A)
+
+    np.testing.assert_array_equal(bopdmd_with_A.atilde, bopdmd_no_A.atilde)
+    np.testing.assert_array_equal(bopdmd_with_A.modes, bopdmd_no_A.modes)
+    np.testing.assert_array_equal(bopdmd_with_A.eigs, bopdmd_no_A.eigs)


### PR DESCRIPTION
Hi! This PR just involves a tiny (yet crucial) edit to the `BOPDMD` module, which is the addition of a `compute_A` flag.

Previously, I programmed the `BOPDMD` module so that it computes the full Koopman operator $A$ all of the time. However, this can get problematic, especially in the event where one's data is sufficiently high-dimensional and $A$ becomes prohibitively expensive to compute. Thus, I've added the `compute_A` parameter to the module, which allows users to choose whether or not they would like the module to compute $A$, since computing $A$ still has potential to be helpful, especially when one is dealing with data from small systems of ODEs or just smaller datasets in general.