### PR TITLE
Added PiDMD

### DIFF
--- a/docs/source/pidmd.rst
+++ b/docs/source/pidmd.rst
@@ -1,0 +1,14 @@
+Physics-informed DMD
+====================
+
+.. currentmodule:: pydmd.pidmd
+
+.. automodule:: pydmd.pidmd
+
+.. autoclass:: PiDMD
+	:members:
+	:private-members:
+	:undoc-members:
+	:show-inheritance:
+	:noindex:
+

--- a/pydmd/__init__.py
+++ b/pydmd/__init__.py
@@ -2,7 +2,7 @@
 PyDMD init
 """
 __all__ = ['dmdbase', 'dmd', 'fbdmd', 'mrdmd', 'cdmd', 'hodmd', 'dmdc',
-           'optdmd', 'hankeldmd', 'rdmd', 'havok', 'bopdmd']
+           'optdmd', 'hankeldmd', 'rdmd', 'havok', 'bopdmd', 'pidmd']
 
 
 from .meta import *
@@ -22,3 +22,4 @@ from .subspacedmd import SubspaceDMD
 from .rdmd import RDMD
 from .havok import HAVOK
 from .bopdmd import BOPDMD
+from .pidmd import PiDMD

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -124,7 +124,7 @@ class PiDMDOperator(DMDOperator):
         if manifold_opt is None:
             ind_mat = np.ones((nx, 2), dtype=int)
         elif isinstance(manifold_opt, int) and manifold_opt > 0:
-            ind_mat = manifold_opt * np.ones((nx, 2))
+            ind_mat = manifold_opt * np.ones((nx, 2), dtype=int)
         elif (isinstance(manifold_opt, tuple)
                 and len(manifold_opt) == 2
                 and np.all(np.array(manifold_opt) > 0)):

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -1,0 +1,535 @@
+"""
+Derived module from dmd.py for Physics-informed DMD.
+
+References:
+- Peter J. Baddoo, Benjamin Herrmann, Beverley J. McKeon, J. Nathan Kutz, and
+Steven L. Brunton. Physics-informed dynamic mode decomposition (pidmd). 2021.
+arXiv:2112.04307.
+"""
+import numpy as np
+from scipy import sparse
+from scipy.linalg import block_diag, rq
+from numpy.fft import fft, ifft, fft2
+
+from .dmd import DMD
+from .dmdoperator import DMDOperator
+from .utils import compute_svd
+from .rdmd import compute_rank
+
+
+class PiDMDOperator(DMDOperator):
+    """
+    DMD operator for Physics-informed DMD.
+
+    :param manifold: the matrix manifold for the full DMD operator A.
+    :type manifold: str
+    :param manifold_opt: option used to specify certain manifolds. If manifold
+        is "diagonal", manifold_opt may be used to specify the width of the
+        diagonal of A. If manifold starts with "BC", manifold_opt must be a
+        2D tuple that specifies the desired dimensions of the blocks of A.
+    :type manifold_opt: int, tuple(int,int), or numpy.ndarray
+    :param compute_A: Flag that determines whether or not to compute the full
+        Koopman operator A.
+    :type compute_A: bool
+    :param svd_rank: the rank for the truncation; If 0, the method computes the
+        optimal rank and uses it for truncation; if positive integer, the
+        method uses the argument for the truncation; if float between 0 and 1,
+        the rank is the number of the biggest singular values that are needed
+        to reach the 'energy' specified by `svd_rank`; if -1, the method does
+        not compute truncation.
+    :type svd_rank: int or float
+    """
+    def __init__(
+        self,
+        manifold,
+        manifold_opt,
+        compute_A,
+        svd_rank,
+    ):
+        self._manifold = manifold
+        self._manifold_opt = manifold_opt
+        self._compute_A = compute_A
+        self._svd_rank = svd_rank
+
+        self._A = None
+        self._Atilde = None
+        self._eigenvalues = None
+        self._eigenvectors = None
+        self._modes = None
+
+
+    @property
+    def A(self):
+        """
+        Get the full Koopman operator A.
+
+        :return: the full Koopman operator A.
+        :rtype: numpy.ndarray
+        """
+        if not self._compute_A:
+            msg = "A not computed during fit. " \
+                  "Set parameter compute_A = True to compute A."
+            raise ValueError(msg)
+        if self._A is None:
+            raise ValueError("You need to call fit before")
+        return self._A
+
+
+    def _check_compute_A(self, manifold):
+        """
+        Helper method that checks that compute_A is True.
+        Throws an error if compute_A is False.
+        """
+        if not self._compute_A:
+            raise ValueError(
+                f"A must be computed for manifold {manifold}."
+                "Set compute_A = True to compute A."
+            )
+
+
+    def _compute_procrustes(self, X, Y, manifold, manifold_opt=None):
+        """
+        Private method that computes the best-fit linear operator A in the
+        relationship Y=AX such that A is restricted to the family of matrices
+        defined by the given manifold (and manifold option if applicable).
+        Computes and returns either (1) the eigenvalues and eigenvectors of A,
+        (2) the reduced operator atilde, or (3) the full operator A, depending
+        on the chosen manifold and the compute_A parameter.
+
+        :return: eigenvalues of A, eigenvectors of A, reduced operator atilde,
+            and the full operator A. None is returned for quantities that are
+            not computed.
+        :rtype: [numpy.ndarray, numpy.ndarray, NoneType, NoneType],
+            [NoneType, NoneType, numpy.ndarray, NoneType], or
+            [NoneType, NoneType, NoneType, numpy.ndarray]
+        """
+        nx, nt = X.shape
+        eigenvalues = None
+        modes = None
+        atilde = None
+        A = None
+
+        # A unitary (conservative systems).
+        if manifold == "unitary":
+            Ux = compute_svd(X, self._svd_rank)[0]
+            Yproj = Ux.conj().T.dot(Y)
+            Xproj = Ux.conj().T.dot(X)
+            Uyx, _, Vyx = compute_svd(Yproj.dot(Xproj.conj().T), -1)
+            atilde = Uyx.dot(Vyx.conj().T)
+
+        # A uppertriangular/lowertriangular (causal systems).
+        elif manifold == "uppertriangular":
+            self._check_compute_A(manifold)
+            R, Q = rq(X, mode="economic")
+            Ut = np.triu(Y.dot(Q.conj().T))
+            A = np.linalg.lstsq(R.T, Ut.T, rcond=None)[0].T
+        elif manifold == "lowertriangular":
+            self._check_compute_A(manifold)
+            A_rot = self._compute_procrustes(
+                np.flipud(X), np.flipud(Y), manifold="uppertriangular")[-1]
+            A = np.rot90(A_rot, 2)
+
+        # A banded along diagonal (spatially local systems).
+        elif manifold == "diagonal":
+            # Specify the index matrix for the diagonals of A.
+            if manifold_opt is None:
+                ind_mat = np.ones((nx, 2))
+            elif isinstance(manifold_opt, int) and manifold_opt > 0:
+                ind_mat = manifold_opt * np.ones((nx, 2))
+            elif (isinstance(manifold_opt, tuple)
+                  and len(manifold_opt) == 2
+                  and np.all(np.array(manifold_opt) > 0)):
+                ind_mat = np.ones((nx, 2))
+                ind_mat[:, 0] *= manifold_opt[0]
+                ind_mat[:, 1] *= manifold_opt[1]
+            elif (isinstance(manifold_opt, np.ndarray)
+                  and manifold_opt.shape == (nx, 2)
+                  and np.all(manifold_opt > 0)):
+                ind_mat = manifold_opt
+            else:
+                raise ValueError("manifold_opt is not in an allowable format.")
+
+            # Keep track of info for building A as a sparse coordinate matrix.
+            I = []
+            J = []
+            R = []
+
+            # Solve min||Cx-b|| along each row.
+            for j in range(nx):
+                l1 = int(max(j-(ind_mat[j,0]-1), 0))
+                l2 = int(min(j+(ind_mat[j,1]-1), nx-1) + 1)
+                C = X[l1:l2, :].T
+                b = Y[j, :].T
+                x = np.linalg.lstsq(C, b, rcond=None)[0].T
+                I.append(j * np.ones(l2 - l1))
+                J.append(np.arange(l1, l2))
+                R.append(x)
+
+            # Build A as a sparse matrix.
+            I_mat = np.hstack(I)
+            J_mat = np.hstack(J)
+            R_mat = np.hstack(R)
+            A_sparse = sparse.coo_array((R_mat, (I_mat,J_mat)), shape=(nx,nx))
+
+            if self._compute_A:
+                A = A_sparse.toarray()
+            else:
+                eigenvalues, modes = sparse.linalg.eigs(A_sparse, k=nx-2)
+
+        # A symmetric (self-adjoint systems) or skew-symmetric.
+        elif manifold in ["symmetric", "skewsymmetric"]:
+            U, s, V = compute_svd(X, -1)
+            C = np.linalg.multi_dot([U.conj().T, Y, V])
+            r = compute_rank(X, self._svd_rank)
+            atilde = np.zeros((r, r), dtype="complex")
+
+            if manifold == "symmetric":
+                for i in range(r):
+                    atilde[i, i] = C[i, i].real / s[i]
+                    for j in range(i + 1, r):
+                        atilde[i, j] = s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
+                        atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
+                atilde += atilde.conj().T - np.diag(np.diag(atilde.real))
+            else: # skewsymmetric
+                for i in range(r):
+                    atilde[i, i] = 1j * (C[i, i].imag / s[i])
+                    for j in range(i + 1, r):
+                        atilde[i, j] = -s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
+                        atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
+                atilde += -atilde.conj().T - 1j * np.diag(np.diag(atilde.imag))
+
+        elif manifold in ["toeplitz", "hankel"]:
+            self._check_compute_A(manifold)
+            if manifold == "toeplitz":
+                J = np.eye(nx)
+            else: # hankel
+                J = np.fliplr(np.eye(nx))
+
+            # Shorthand for readability.
+            IZx = np.hstack([np.eye(nx), np.zeros((nx, nx))])
+
+            # Define left and right matrices.
+            Am = fft(IZx.T, axis=0).conj().T / np.sqrt(2 * nx)
+            B = fft(np.hstack(
+                [J.dot(X).conj().T, np.zeros((nt, nx))]
+            ).T, axis=0).conj().T / np.sqrt(2 * nx)
+
+            # Compute AA* and B*B (fast computation of AA*).
+            AAt = ifft(fft(np.vstack(
+                [IZx, np.zeros((nx, 2*nx))]
+            ), axis=0).T, axis=0).T
+            BtB = B.conj().T.dot(B)
+
+            # Solve linear system y = dL.
+            y = np.diag(np.linalg.multi_dot([Am.conj().T,Y.conj(),B])).conj().T
+            L = np.multiply(AAt, BtB.T).conj().T
+            d = np.linalg.lstsq(L[:-1, :-1].T, y[:-1], rcond=None)[0]
+            d = np.append(d, 0)
+
+            # Convert eigenvalues into circulant matrix.
+            new_A = ifft(fft(np.diag(d), axis=0).T, axis=0).T
+
+            # Extract toeplitz matrix from the circulant matrix.
+            A = new_A[:nx, :nx].dot(J)
+
+        # A circulant (shift-invariant systems).
+        elif manifold in [
+            "circulant",
+            "circulant_unitary",
+            "circulant_symmetric",
+            "circulant_skewsymmetric"
+        ]:
+            fX = fft(X, axis=0)
+            fY = fft(Y.conj(), axis=0)
+            fX_norm = np.linalg.norm(fX, axis=1)
+            d = np.divide(np.diag(fX.dot(fY.conj().T)), fX_norm ** 2)
+
+            if manifold == "circulant_unitary":
+                d = np.exp(1j * np.angle(d))
+            elif manifold == "circulant_symmetric":
+                d = d.real
+            elif manifold == "circulant_skewsymmetric":
+                d = 1j * d.imag
+
+            # Remove the least important eigenvalues.
+            r = compute_rank(X, self._svd_rank)
+            res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
+                            np.linalg.norm(fX.conj().T, 2, axis=0).T)
+            ind_exclude = np.argpartition(res, nx-r)[:nx-r]
+            d[ind_exclude] = 0
+
+            if self._compute_A:
+                A = fft(np.multiply(d, ifft(np.eye(nx), axis=0).T).T, axis=0)
+            else:
+                eigenvalues = np.delete(d, ind_exclude)
+                modes = np.delete(fft(np.eye(nx),axis=0), ind_exclude, axis=1)
+
+        elif manifold == "symmetric_tridiagonal":
+            # Form the leading block.
+            T1e = np.linalg.norm(X, axis=1) ** 2
+            T1 = sparse.diags(T1e)
+
+            # Form the second and third blocks.
+            T2e = np.diag(X[1:, :].dot(X[:-1, :].T))
+            T2 = sparse.spdiags([T2e, T2e], diags=[-1, 0], m=nx, n=nx-1)
+
+            # Form the final block.
+            T3e = np.insert(np.diag(X[2:, :].dot(X[:-2, :].T)), 0, 0)
+            T3_offdiag = sparse.spdiags(T3e, diags=1, m=nx-1, n=nx-1)
+            T3 = sparse.spdiags(T1e[:-1] + T1e[1:], diags=0, m=nx-1, n=nx-1) \
+                 + T3_offdiag + T3_offdiag.conj().T
+
+            # Form the symmetric block-tridiagonal matrix T = [T1  T2; T2* T3].
+            T = sparse.vstack(
+                [sparse.hstack([T1, T2]), sparse.hstack([T2.conj().T, T3])]
+            )
+
+            # Solve for c in the system Tc = d.
+            d1 = np.diag(X.dot(Y.T))
+            d2 = np.diag(X[:-1, :].dot(Y[1:, :].T)) \
+                 + np.diag(X[1:, :].dot(Y[:-1, :].T))
+            d = np.concatenate((d1, d2), axis=None)
+            c = sparse.linalg.lsqr(T.real, d.real)[0]
+
+            # Form the solution matrix A.
+            A_sparse = sparse.diags(c[:nx])
+            A_sparse += sparse.spdiags(np.insert(c[nx:],0,0),diags=1,m=nx,n=nx)
+            A_sparse += sparse.spdiags(np.append(c[nx:],0),diags=-1,m=nx,n=nx)
+
+            if self._compute_A:
+                A = A_sparse.toarray()
+            else:
+                eigenvalues, modes = sparse.linalg.eigs(A_sparse, k=nx-2)
+
+        elif manifold in [
+            "BC",
+            "BCTB",
+            "BCCB", "BCCBskewsymmetric", "BCCBsymmetric", "BCCBunitary"
+        ]:
+            self._check_compute_A(manifold)
+            # Specify the shape of the blocks in the output matrix A.
+            if manifold_opt is None:
+                raise ValueError("manifold_opt must be specified.")
+            if (not isinstance(manifold_opt,tuple) or len(manifold_opt) != 2):
+                raise ValueError("manifold_opt is not in an allowable format.")
+            block_shape = np.array(manifold_opt)
+
+            if manifold.startswith("BCCB"):
+                def fft_block2d(X):
+                    """
+                    Helper method that, given a 2D numpy array X, reshapes the
+                    columns of X into arrays of shape block_shape, computes the
+                    2D discrete Fourier Transform, and returns the resulting
+                    FFT matrix restored to the original X shape and scaled
+                    according to the length of the columns of X.
+                    """
+                    m, n = X.shape
+                    Y = X.reshape(*block_shape, n, order="F")
+                    Y_fft2 = fft2(Y, axes=(0, 1))
+                    return Y_fft2.reshape(m, n, order="F") / np.sqrt(m)
+
+                fX = fft_block2d(X.conj())
+                fY = fft_block2d(Y.conj())
+                d = np.zeros(nx, dtype="complex")
+
+                if manifold == "BCCB":
+                    for j in range(nx):
+                        d[j] = np.dot(fX[j,:], fY[j,:].conj()).conj()
+                        d[j] /= np.linalg.norm(fX[j, :].conj(), 2)**2
+                else:
+                    for j in range(nx):
+                        dp = np.linalg.lstsq(
+                            fX[j,:,None], fY[j,:,None], rcond=None)[0][0][0]
+                        if manifold == "BCCBskewsymmetric":
+                            d[j] = 1j * dp.imag
+                        elif manifold == "BCCBsymmetric":
+                            d[j] = dp.real
+                        else: # BCCBunitary
+                            d[j] = np.exp(1j * np.angle(dp))
+
+                # Remove the least important eigenvalues.
+                r = compute_rank(X, self._svd_rank)
+                res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
+                                np.linalg.norm(fX.conj().T, 2, axis=0).T)
+                ind_exclude = np.argpartition(res, nx-r)[:nx-r]
+                d[ind_exclude] = 0
+                fI = fft_block2d(np.eye(nx))
+                A = fft_block2d(np.multiply(d.conj(), fI.conj().T).T)
+
+            else:
+                def fft_block(X):
+                    """
+                    Helper method that, given a 2D numpy array X, reshapes the
+                    columns of X into arrays of shape block_shape, computes the
+                    1D discrete Fourier Transform, and returns the resulting
+                    FFT matrix restored to the original X shape and scaled
+                    according to the number of columns per block.
+                    """
+                    m, n = X.shape
+                    Y = X.reshape(*block_shape, n, order="F")
+                    Y_fft = fft(Y, axis=1)
+                    return Y_fft.reshape(m,n,order="F")/np.sqrt(block_shape[1])
+
+                fX = fft_block(X)
+                fY = fft_block(Y)
+                d = []
+
+                for j in range(block_shape[1]):
+                    ls = (j * block_shape[0]) + np.arange(block_shape[0])
+                    if manifold == "BC":
+                        sol = np.linalg.lstsq(
+                            fX[ls, :].T, fY[ls, :].T, rcond=None)[0].T
+                    else: # BCTB
+                        sol = self._compute_procrustes(
+                            fX[ls,:],
+                            fY[ls,:],
+                            manifold="diagonal",
+                            manifold_opt=2
+                        )[-1]
+                    d.append(sol)
+
+                bd = block_diag(*d)
+                fI = fft_block(np.eye(nx))
+                A = fft_block(bd.dot(fI).conj()).conj()
+        else:
+            raise ValueError("The selected manifold is not implemented.")
+
+        return eigenvalues, modes, atilde, A
+
+    def compute_operator(self, X, Y):
+        """
+        Compute the low-rank operator and the full operator A.
+
+        :param X: matrix containing the snapshots x0,..x{n-1} by column.
+        :type X: numpy.ndarray
+        :param Y: matrix containing the snapshots x1,..x{n} by column.
+        :type Y: numpy.ndarray
+        :return: the (truncated) left-singular vectors matrix, the (truncated)
+            singular values array, and the (truncated) right-singular vectors
+            matrix of X.
+        :rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
+        """
+        U, s, V = compute_svd(X, self._svd_rank)
+
+        eigenvalues, modes, atilde, A = self._compute_procrustes(
+            X, Y, self._manifold, self._manifold_opt
+        )
+        # Case 1: atilde was computed.
+        if atilde is not None:
+            eigenvalues, eigenvectors = np.linalg.eig(atilde)
+            modes = U.dot(eigenvectors)
+            if self._compute_A:
+                A = np.linalg.multi_dot([modes,
+                                         np.diag(eigenvalues),
+                                         np.linalg.pinv(modes)])
+        # Cases 2,3: A was computed, or eigs/modes were computed.
+        else:
+            if eigenvalues is None or modes is None:
+                eigenvalues, modes = np.linalg.eig(A)
+            eigenvectors = U.conj().T.dot(modes)
+            atilde = np.linalg.multi_dot([U.conj().T, A, U])
+
+        self._A = A
+        self._Atilde = atilde
+        self._eigenvalues = eigenvalues
+        self._eigenvectors = eigenvectors
+        self._modes = modes
+
+        return U, s, V
+
+class PiDMD(DMD):
+    """
+    Physics-informed Dynamic Mode Decomposition.
+
+    :param manifold: the matrix manifold to restrict the full operator A to.
+        The following matrix manifolds are permissible:
+        - "unitary"
+        - "uppertriangular"
+        - "lowertriangular"
+        - "diagonal"
+        - "symmetric",
+        - "skewsymmetric"
+        - "toeplitz"
+        - "hankel"
+        - "circulant"
+        - "circulant_unitary"
+        - "circulant_symmetric"
+        - "circulant_skewsymmetric"
+        - "symmetric_tridiagonal"
+        - "BC" (block circulant)
+        - "BCTB" (BC with tridiagonal blocks)
+        - "BCCB" (BC with circulant blocks)
+        - "BCCBunitary" (BCCB and unitary)
+        - "BCCBsymmetric" (BCCB and symmetric)
+        - "BCCBskewsymmetric" (BCCB and skewsymmetric)
+    :type manifold: str
+    :param manifold_opt: option used to specify certain manifolds.
+        If manifold is "diagonal", manifold_opt may be used to specify the
+        width of the diagonal of A. If manifold_opt is an integer k, A is
+        banded, with a lower and upper bandwidth of k-1. If manifold_opt is
+        a tuple containing two integers k1 and k2, A is banded with a lower
+        bandwidth of k1-1 and an upper bandwidth of k2-1. Finally, if
+        manifold_opt is a numpy array of size (len(X), 2), the entries of
+        manifold_opt are used to explicitly define the the upper and lower
+        bounds of the indices of the non-zero elements of A.
+        If manifold starts with "BC", manifold_opt must be a 2D tuple that
+        specifies the desired dimensions of the blocks of A.
+        Note that all other manifolds do not use manifold_opt.
+    :type manifold_opt: int, tuple(int,int), or numpy.ndarray
+    :param compute_A: Flag that determines whether or not to compute the full
+        Koopman operator A.
+    :type compute_A: bool
+    :param svd_rank: the rank for the truncation; If 0, the method computes the
+        optimal rank and uses it for truncation; if positive integer, the
+        method uses the argument for the truncation; if float between 0 and 1,
+        the rank is the number of the biggest singular values that are needed
+        to reach the 'energy' specified by `svd_rank`; if -1, the method does
+        not compute truncation. Default is -1, meaning no truncation.
+    :type svd_rank: int or float
+    :param tlsq_rank: rank truncation computing Total Least Square. Default is
+        0, meaning no truncation.
+    :type tlsq_rank: int
+    :param opt: If True, amplitudes are computed like in optimized DMD  (see
+        :func:`~dmdbase.DMDBase._compute_amplitudes` for reference). If
+        False, amplitudes are computed following the standard algorithm. If
+        `opt` is an integer, it is used as the (temporal) index of the snapshot
+        used to compute DMD modes amplitudes (following the standard
+        algorithm).
+        The reconstruction will generally be better in time instants near the
+        chosen snapshot; however increasing `opt` may lead to wrong results
+        when the system presents small eigenvalues. For this reason a manual
+        selection of the number of eigenvalues considered for the analyisis may
+        be needed (check `svd_rank`). Also setting `svd_rank` to a value
+        between 0 and 1 may give better results. Default is False.
+    :type opt: bool or int
+    """
+    def __init__(
+        self,
+        manifold,
+        manifold_opt=None,
+        compute_A=False,
+        svd_rank=-1,
+        tlsq_rank=0,
+        opt=False,
+    ):
+        super().__init__(
+            svd_rank=svd_rank,
+            tlsq_rank=tlsq_rank,
+            opt=opt,
+        )
+        self._Atilde = PiDMDOperator(
+            manifold=manifold,
+            manifold_opt=manifold_opt,
+            compute_A=compute_A,
+            svd_rank=svd_rank,
+        )
+
+    @property
+    def A(self):
+        """
+        Get the full Koopman operator A.
+
+        :return: the full Koopman operator A.
+        :rtype: numpy.ndarray
+        """
+        return self.operator.A

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -122,7 +122,7 @@ class PiDMDOperator(DMDOperator):
         # Specify the index matrix for the diagonals of A.
         nx = len(X)
         if manifold_opt is None:
-            ind_mat = np.ones((nx, 2))
+            ind_mat = np.ones((nx, 2), dtype=int)
         elif isinstance(manifold_opt, int) and manifold_opt > 0:
             ind_mat = manifold_opt * np.ones((nx, 2))
         elif (isinstance(manifold_opt, tuple)

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -75,17 +75,341 @@ class PiDMDOperator(DMDOperator):
         return self._A
 
 
-    def _check_compute_A(self, manifold):
+    def _check_compute_A(self):
         """
         Helper method that checks that compute_A is True.
         Throws an error if compute_A is False.
         """
         if not self._compute_A:
             raise ValueError(
-                f"A must be computed for manifold {manifold}."
+                "A must be computed for the chosen manifold."
                 "Set compute_A = True to compute A."
             )
 
+
+    def _compute_unitary(self, X, Y):
+        """
+        Given the data matrices X and Y, solves the for the best-fit unitary
+        operator A that solves the relationship Y=AX. Returns the corresponding
+        reduced operator atilde.
+        """
+        Ux = compute_svd(X, self._svd_rank)[0]
+        Yproj = Ux.conj().T.dot(Y)
+        Xproj = Ux.conj().T.dot(X)
+        Uyx, _, Vyx = compute_svd(Yproj.dot(Xproj.conj().T), -1)
+        atilde = Uyx.dot(Vyx.conj().T)
+        return atilde
+
+
+    def _compute_uppertriangular(self, X, Y):
+        """
+        Given the data matrices X and Y, solves for and returns the best-fit
+        uppertriangular matrix A that solves the relationship Y=AX.
+        """
+        self._check_compute_A()
+        R, Q = rq(X, mode="economic")
+        Ut = np.triu(Y.dot(Q.conj().T))
+        A = np.linalg.lstsq(R.T, Ut.T, rcond=None)[0].T
+        return A
+
+
+    def _compute_diagonal(self, X, Y, manifold_opt):
+        """
+        Given the data matrices X and Y and specification for the diagonals of
+        the matrix A, solves for and returns the best-fit matrix A that solves
+        the relationship Y=AX and has diagonal entries specified by
+        manifold_opt. Only the eigenvalues and eigenvectors of A are returned
+        if the compute_A flag is not True.
+        """
+        # Specify the index matrix for the diagonals of A.
+        nx = len(X)
+        if manifold_opt is None:
+            ind_mat = np.ones((nx, 2))
+        elif isinstance(manifold_opt, int) and manifold_opt > 0:
+            ind_mat = manifold_opt * np.ones((nx, 2))
+        elif (isinstance(manifold_opt, tuple)
+                and len(manifold_opt) == 2
+                and np.all(np.array(manifold_opt) > 0)):
+            ind_mat = np.ones((nx, 2))
+            ind_mat[:, 0] *= manifold_opt[0]
+            ind_mat[:, 1] *= manifold_opt[1]
+        elif (isinstance(manifold_opt, np.ndarray)
+                and manifold_opt.shape == (nx, 2)
+                and np.all(manifold_opt > 0)):
+            ind_mat = manifold_opt
+        else:
+            raise ValueError("manifold_opt is not in an allowable format.")
+
+        # Keep track of info for building A as a sparse coordinate matrix.
+        I = []
+        J = []
+        R = []
+
+        # Solve min||Cx-b|| along each row.
+        for j in range(nx):
+            l1 = int(max(j-(ind_mat[j,0]-1), 0))
+            l2 = int(min(j+(ind_mat[j,1]-1), nx-1) + 1)
+            C = X[l1:l2, :].T
+            b = Y[j, :].T
+            I.append(j * np.ones(l2 - l1))
+            J.append(np.arange(l1, l2))
+            R.append(np.linalg.lstsq(C, b, rcond=None)[0].T)
+
+        # Build A as a sparse matrix.
+        A_sparse = sparse.coo_array(
+            (np.hstack(R), (np.hstack(I), np.hstack(J))), shape=(nx,nx)
+        )
+
+        if self._compute_A:
+            return None, None, A_sparse.toarray()
+
+        return sparse.linalg.eigs(A_sparse, k=nx-2), None
+
+
+    def _compute_symmetric(self, X, Y, skewsymmetric=False):
+        """
+        Given the data matrices X and Y, solves the for the best-fit symmetric
+        (or skewsymmetric) operator A that solves the relationship Y=AX.
+        Returns the corresponding reduced operator atilde.
+        """
+        U, s, V = compute_svd(X, -1)
+        C = np.linalg.multi_dot([U.conj().T, Y, V])
+        r = compute_rank(X, self._svd_rank)
+        atilde = np.zeros((r, r), dtype="complex")
+
+        if skewsymmetric:
+            for i in range(r):
+                atilde[i, i] = 1j * (C[i, i].imag / s[i])
+                for j in range(i + 1, r):
+                    atilde[i, j] = -s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
+                    atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
+            atilde += -atilde.conj().T - 1j * np.diag(np.diag(atilde.imag))
+        else: # symmetric
+            for i in range(r):
+                atilde[i, i] = C[i, i].real / s[i]
+                for j in range(i + 1, r):
+                    atilde[i, j] = s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
+                    atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
+            atilde += atilde.conj().T - np.diag(np.diag(atilde.real))
+
+        return atilde
+
+
+    def _compute_toeplitz(self, X, Y, flipped=False):
+        """
+        Given the data matrices X and Y, solves for and returns the
+        best-fit toeplitz (or hankel if flipped=True) operator A that
+        solves the relationship Y=AX.
+        """
+        self._check_compute_A()
+        nx, nt = X.shape
+        if flipped: # hankel
+            J = np.fliplr(np.eye(nx))
+        else: # toeplitz
+            J = np.eye(nx)
+
+        # Shorthand for readability.
+        IZx = np.hstack([np.eye(nx), np.zeros((nx, nx))])
+
+        # Define left and right matrices.
+        Am = fft(IZx.T, axis=0).conj().T / np.sqrt(2 * nx)
+        B = fft(np.hstack(
+            [J.dot(X).conj().T, np.zeros((nt, nx))]
+        ).T, axis=0).conj().T / np.sqrt(2 * nx)
+
+        # Compute AA* and B*B (fast computation of AA*).
+        AAt = ifft(fft(np.vstack(
+            [IZx, np.zeros((nx, 2*nx))]
+        ), axis=0).T, axis=0).T
+        BtB = B.conj().T.dot(B)
+
+        # Solve linear system y = dL.
+        y = np.diag(np.linalg.multi_dot([Am.conj().T,Y.conj(),B])).conj().T
+        L = np.multiply(AAt, BtB.T).conj().T
+        d = np.linalg.lstsq(L[:-1, :-1].T, y[:-1], rcond=None)[0]
+        d = np.append(d, 0)
+
+        # Convert eigenvalues into circulant matrix.
+        new_A = ifft(fft(np.diag(d), axis=0).T, axis=0).T
+
+        # Extract toeplitz matrix from the circulant matrix.
+        A = new_A[:nx, :nx].dot(J)
+
+        return A
+
+
+    def _compute_circulant(self, X, Y, circulant_opt):
+        """
+        Given the data matrices X and Y, solves for and returns the best-fit
+        circulant matrix A that solves the relationship Y=AX and satisfies any
+        additional conditions set by circulant_opt. Only the eigenvalues and
+        eigenvectors of A are returned if the compute_A flag is not True.
+        """
+        nx = len(X)
+        fX = fft(X, axis=0)
+        fY = fft(Y.conj(), axis=0)
+        fX_norm = np.linalg.norm(fX, axis=1)
+        d = np.divide(np.diag(fX.dot(fY.conj().T)), fX_norm ** 2)
+
+        if circulant_opt == "unitary":
+            d = np.exp(1j * np.angle(d))
+        elif circulant_opt == "symmetric":
+            d = d.real
+        elif circulant_opt == "skewsymmetric":
+            d = 1j * d.imag
+
+        # Remove the least important eigenvalues.
+        r = compute_rank(X, self._svd_rank)
+        res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
+                        np.linalg.norm(fX.conj().T, 2, axis=0).T)
+        ind_exclude = np.argpartition(res, nx-r)[:nx-r]
+        d[ind_exclude] = 0
+
+        if self._compute_A:
+            A = fft(np.multiply(d, ifft(np.eye(nx), axis=0).T).T, axis=0)
+            return None, None, A
+
+        eigenvalues = np.delete(d, ind_exclude)
+        modes = np.delete(fft(np.eye(nx),axis=0), ind_exclude, axis=1)
+        return eigenvalues, modes, None
+
+
+    def _compute_symtridiagonal(self, X, Y):
+        """
+        Given the data matrices X and Y, solves for and returns the best-fit
+        symmetric tridiagonal matrix A that solves the relationship Y=AX.
+        Only the eigenvalues and eigenvectors of A are returned if the
+        compute_A flag is not True.
+        """
+        nx = len(X)
+
+        # Form the leading block.
+        T1e = np.linalg.norm(X, axis=1) ** 2
+        T1 = sparse.diags(T1e)
+
+        # Form the second and third blocks.
+        T2e = np.diag(X[1:, :].dot(X[:-1, :].T))
+        T2 = sparse.spdiags([T2e, T2e], diags=[-1, 0], m=nx, n=nx-1)
+
+        # Form the final block.
+        T3e = np.insert(np.diag(X[2:, :].dot(X[:-2, :].T)), 0, 0)
+        T3_offdiag = sparse.spdiags(T3e, diags=1, m=nx-1, n=nx-1)
+        T3 = sparse.spdiags(T1e[:-1] + T1e[1:], diags=0, m=nx-1, n=nx-1) \
+                + T3_offdiag + T3_offdiag.conj().T
+
+        # Form the symmetric block-tridiagonal matrix T = [T1  T2; T2* T3].
+        T = sparse.vstack(
+            [sparse.hstack([T1, T2]), sparse.hstack([T2.conj().T, T3])]
+        )
+
+        # Solve for c in the system Tc = d.
+        d1 = np.diag(X.dot(Y.T))
+        d2 = np.diag(X[:-1, :].dot(Y[1:, :].T)) \
+                + np.diag(X[1:, :].dot(Y[:-1, :].T))
+        d = np.concatenate((d1, d2), axis=None)
+        c = sparse.linalg.lsqr(T.real, d.real)[0]
+
+        # Form the solution matrix A.
+        A_sparse = sparse.diags(c[:nx])
+        A_sparse += sparse.spdiags(np.insert(c[nx:],0,0),diags=1,m=nx,n=nx)
+        A_sparse += sparse.spdiags(np.append(c[nx:],0),diags=-1,m=nx,n=nx)
+
+        if self._compute_A:
+            return None, None, A_sparse.toarray()
+
+        return sparse.linalg.eigs(A_sparse, k=nx-2), None
+
+
+    def _compute_BCCB(self, X, Y, block_shape, bccb_opt):
+        """
+        Given the data matrices X and Y, solves for and returns the best-fit
+        BCCB (block circulant with circulant blocks) matrix A that solves the
+        relationship Y=AX. The blocks of A will have the shape block_shape and
+        will have the additional matrix property given by bccb_opt.
+        """
+        def fft_block2d(X):
+            """
+            Helper method that, given a 2D numpy array X, reshapes the
+            columns of X into arrays of shape block_shape, computes the
+            2D discrete Fourier Transform, and returns the resulting
+            FFT matrix restored to the original X shape and scaled
+            according to the length of the columns of X.
+            """
+            m, n = X.shape
+            Y = X.reshape(*block_shape, n, order="F")
+            Y_fft2 = fft2(Y, axes=(0, 1))
+            return Y_fft2.reshape(m, n, order="F") / np.sqrt(m)
+
+        nx = len(X)
+        fX = fft_block2d(X.conj())
+        fY = fft_block2d(Y.conj())
+        d = np.zeros(nx, dtype="complex")
+
+        if not bccb_opt:
+            for j in range(nx):
+                d[j] = np.dot(fX[j,:], fY[j,:].conj()).conj()
+                d[j] /= np.linalg.norm(fX[j, :].conj(), 2)**2
+        else:
+            for j in range(nx):
+                dp = np.linalg.lstsq(
+                    fX[j,:,None], fY[j,:,None], rcond=None)[0][0][0]
+                if bccb_opt == "unitary":
+                    d[j] = np.exp(1j * np.angle(dp))
+                elif bccb_opt == "symmetric":
+                    d[j] = dp.real
+                else: # skewsymmetric
+                    d[j] = 1j * dp.imag
+
+        # Remove the least important eigenvalues.
+        r = compute_rank(X, self._svd_rank)
+        res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
+                        np.linalg.norm(fX.conj().T, 2, axis=0).T)
+        ind_exclude = np.argpartition(res, nx-r)[:nx-r]
+        d[ind_exclude] = 0
+        fI = fft_block2d(np.eye(nx))
+        A = fft_block2d(np.multiply(d.conj(), fI.conj().T).T)
+
+        return A
+
+
+    def _compute_BC(self, X, Y, block_shape, tridiagonal_blocks=False):
+        """
+        Given the data matrices X and Y, solves for and returns the best-fit
+        BC (block circulant) matrix A that solves the relationship Y=AX. The
+        blocks of A will have the shape block_shape and will be tridiagonal
+        if tridiagonal_blocks is True.
+        """
+        def fft_block(X):
+            """
+            Helper method that, given a 2D numpy array X, reshapes the
+            columns of X into arrays of shape block_shape, computes the
+            1D discrete Fourier Transform, and returns the resulting
+            FFT matrix restored to the original X shape and scaled
+            according to the number of columns per block.
+            """
+            m, n = X.shape
+            Y = X.reshape(*block_shape, n, order="F")
+            Y_fft = fft(Y, axis=1)
+            return Y_fft.reshape(m,n,order="F")/np.sqrt(block_shape[1])
+
+        nx = len(X)
+        fX = fft_block(X)
+        fY = fft_block(Y)
+        d = []
+
+        for j in range(block_shape[1]):
+            ls = (j * block_shape[0]) + np.arange(block_shape[0])
+            if tridiagonal_blocks:
+                sol = self._compute_diagonal(fX[ls,:], fY[ls,:], 2)
+            else:
+                sol = np.linalg.lstsq(fX[ls,:].T, fY[ls,:].T, rcond=None)[0].T
+            d.append(sol)
+
+        bd = block_diag(*d)
+        fI = fft_block(np.eye(nx))
+        A = fft_block(bd.dot(fI).conj()).conj()
+
+        return A
 
     def _compute_procrustes(self, X, Y, manifold, manifold_opt=None):
         """
@@ -103,210 +427,49 @@ class PiDMDOperator(DMDOperator):
             [NoneType, NoneType, numpy.ndarray, NoneType], or
             [NoneType, NoneType, NoneType, numpy.ndarray]
         """
-        nx, nt = X.shape
+        A = None
+        atilde = None
         eigenvalues = None
         modes = None
-        atilde = None
-        A = None
 
-        # A unitary (conservative systems).
         if manifold == "unitary":
-            Ux = compute_svd(X, self._svd_rank)[0]
-            Yproj = Ux.conj().T.dot(Y)
-            Xproj = Ux.conj().T.dot(X)
-            Uyx, _, Vyx = compute_svd(Yproj.dot(Xproj.conj().T), -1)
-            atilde = Uyx.dot(Vyx.conj().T)
-
-        # A uppertriangular/lowertriangular (causal systems).
+            atilde = self._compute_unitary(X, Y)
         elif manifold == "uppertriangular":
-            self._check_compute_A(manifold)
-            R, Q = rq(X, mode="economic")
-            Ut = np.triu(Y.dot(Q.conj().T))
-            A = np.linalg.lstsq(R.T, Ut.T, rcond=None)[0].T
+            A = self._compute_uppertriangular(X, Y)
         elif manifold == "lowertriangular":
-            self._check_compute_A(manifold)
-            A_rot = self._compute_procrustes(
-                np.flipud(X), np.flipud(Y), manifold="uppertriangular")[-1]
+            A_rot = self._compute_uppertriangular(np.flipud(X), np.flipud(Y))
             A = np.rot90(A_rot, 2)
-
-        # A banded along diagonal (spatially local systems).
         elif manifold == "diagonal":
-            # Specify the index matrix for the diagonals of A.
-            if manifold_opt is None:
-                ind_mat = np.ones((nx, 2))
-            elif isinstance(manifold_opt, int) and manifold_opt > 0:
-                ind_mat = manifold_opt * np.ones((nx, 2))
-            elif (isinstance(manifold_opt, tuple)
-                  and len(manifold_opt) == 2
-                  and np.all(np.array(manifold_opt) > 0)):
-                ind_mat = np.ones((nx, 2))
-                ind_mat[:, 0] *= manifold_opt[0]
-                ind_mat[:, 1] *= manifold_opt[1]
-            elif (isinstance(manifold_opt, np.ndarray)
-                  and manifold_opt.shape == (nx, 2)
-                  and np.all(manifold_opt > 0)):
-                ind_mat = manifold_opt
-            else:
-                raise ValueError("manifold_opt is not in an allowable format.")
-
-            # Keep track of info for building A as a sparse coordinate matrix.
-            I = []
-            J = []
-            R = []
-
-            # Solve min||Cx-b|| along each row.
-            for j in range(nx):
-                l1 = int(max(j-(ind_mat[j,0]-1), 0))
-                l2 = int(min(j+(ind_mat[j,1]-1), nx-1) + 1)
-                C = X[l1:l2, :].T
-                b = Y[j, :].T
-                x = np.linalg.lstsq(C, b, rcond=None)[0].T
-                I.append(j * np.ones(l2 - l1))
-                J.append(np.arange(l1, l2))
-                R.append(x)
-
-            # Build A as a sparse matrix.
-            I_mat = np.hstack(I)
-            J_mat = np.hstack(J)
-            R_mat = np.hstack(R)
-            A_sparse = sparse.coo_array((R_mat, (I_mat,J_mat)), shape=(nx,nx))
-
-            if self._compute_A:
-                A = A_sparse.toarray()
-            else:
-                eigenvalues, modes = sparse.linalg.eigs(A_sparse, k=nx-2)
-
-        # A symmetric (self-adjoint systems) or skew-symmetric.
-        elif manifold in ["symmetric", "skewsymmetric"]:
-            U, s, V = compute_svd(X, -1)
-            C = np.linalg.multi_dot([U.conj().T, Y, V])
-            r = compute_rank(X, self._svd_rank)
-            atilde = np.zeros((r, r), dtype="complex")
-
-            if manifold == "symmetric":
-                for i in range(r):
-                    atilde[i, i] = C[i, i].real / s[i]
-                    for j in range(i + 1, r):
-                        atilde[i, j] = s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
-                        atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
-                atilde += atilde.conj().T - np.diag(np.diag(atilde.real))
-            else: # skewsymmetric
-                for i in range(r):
-                    atilde[i, i] = 1j * (C[i, i].imag / s[i])
-                    for j in range(i + 1, r):
-                        atilde[i, j] = -s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
-                        atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
-                atilde += -atilde.conj().T - 1j * np.diag(np.diag(atilde.imag))
-
-        elif manifold in ["toeplitz", "hankel"]:
-            self._check_compute_A(manifold)
-            if manifold == "toeplitz":
-                J = np.eye(nx)
-            else: # hankel
-                J = np.fliplr(np.eye(nx))
-
-            # Shorthand for readability.
-            IZx = np.hstack([np.eye(nx), np.zeros((nx, nx))])
-
-            # Define left and right matrices.
-            Am = fft(IZx.T, axis=0).conj().T / np.sqrt(2 * nx)
-            B = fft(np.hstack(
-                [J.dot(X).conj().T, np.zeros((nt, nx))]
-            ).T, axis=0).conj().T / np.sqrt(2 * nx)
-
-            # Compute AA* and B*B (fast computation of AA*).
-            AAt = ifft(fft(np.vstack(
-                [IZx, np.zeros((nx, 2*nx))]
-            ), axis=0).T, axis=0).T
-            BtB = B.conj().T.dot(B)
-
-            # Solve linear system y = dL.
-            y = np.diag(np.linalg.multi_dot([Am.conj().T,Y.conj(),B])).conj().T
-            L = np.multiply(AAt, BtB.T).conj().T
-            d = np.linalg.lstsq(L[:-1, :-1].T, y[:-1], rcond=None)[0]
-            d = np.append(d, 0)
-
-            # Convert eigenvalues into circulant matrix.
-            new_A = ifft(fft(np.diag(d), axis=0).T, axis=0).T
-
-            # Extract toeplitz matrix from the circulant matrix.
-            A = new_A[:nx, :nx].dot(J)
-
-        # A circulant (shift-invariant systems).
+            eigenvalues, modes, A = self._compute_diagonal(X, Y, manifold_opt)
+        elif manifold == "symmetric":
+            atilde = self._compute_symmetric(X, Y)
+        elif manifold == "skewsymmetric":
+            atilde = self._compute_symmetric(X, Y, skewsymmetric=True)
+        elif manifold == "toeplitz":
+            A = self._compute_toeplitz(X, Y)
+        elif manifold == "hankel":
+            A = self._compute_toeplitz(X, Y, flipped=True)
         elif manifold in [
             "circulant",
             "circulant_unitary",
             "circulant_symmetric",
             "circulant_skewsymmetric"
         ]:
-            fX = fft(X, axis=0)
-            fY = fft(Y.conj(), axis=0)
-            fX_norm = np.linalg.norm(fX, axis=1)
-            d = np.divide(np.diag(fX.dot(fY.conj().T)), fX_norm ** 2)
-
-            if manifold == "circulant_unitary":
-                d = np.exp(1j * np.angle(d))
-            elif manifold == "circulant_symmetric":
-                d = d.real
-            elif manifold == "circulant_skewsymmetric":
-                d = 1j * d.imag
-
-            # Remove the least important eigenvalues.
-            r = compute_rank(X, self._svd_rank)
-            res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
-                            np.linalg.norm(fX.conj().T, 2, axis=0).T)
-            ind_exclude = np.argpartition(res, nx-r)[:nx-r]
-            d[ind_exclude] = 0
-
-            if self._compute_A:
-                A = fft(np.multiply(d, ifft(np.eye(nx), axis=0).T).T, axis=0)
-            else:
-                eigenvalues = np.delete(d, ind_exclude)
-                modes = np.delete(fft(np.eye(nx),axis=0), ind_exclude, axis=1)
+            circ_opt = manifold.removeprefix("circulant_")
+            eigenvalues, modes, A = self._compute_circulant(X, Y, circ_opt)
 
         elif manifold == "symmetric_tridiagonal":
-            # Form the leading block.
-            T1e = np.linalg.norm(X, axis=1) ** 2
-            T1 = sparse.diags(T1e)
-
-            # Form the second and third blocks.
-            T2e = np.diag(X[1:, :].dot(X[:-1, :].T))
-            T2 = sparse.spdiags([T2e, T2e], diags=[-1, 0], m=nx, n=nx-1)
-
-            # Form the final block.
-            T3e = np.insert(np.diag(X[2:, :].dot(X[:-2, :].T)), 0, 0)
-            T3_offdiag = sparse.spdiags(T3e, diags=1, m=nx-1, n=nx-1)
-            T3 = sparse.spdiags(T1e[:-1] + T1e[1:], diags=0, m=nx-1, n=nx-1) \
-                 + T3_offdiag + T3_offdiag.conj().T
-
-            # Form the symmetric block-tridiagonal matrix T = [T1  T2; T2* T3].
-            T = sparse.vstack(
-                [sparse.hstack([T1, T2]), sparse.hstack([T2.conj().T, T3])]
-            )
-
-            # Solve for c in the system Tc = d.
-            d1 = np.diag(X.dot(Y.T))
-            d2 = np.diag(X[:-1, :].dot(Y[1:, :].T)) \
-                 + np.diag(X[1:, :].dot(Y[:-1, :].T))
-            d = np.concatenate((d1, d2), axis=None)
-            c = sparse.linalg.lsqr(T.real, d.real)[0]
-
-            # Form the solution matrix A.
-            A_sparse = sparse.diags(c[:nx])
-            A_sparse += sparse.spdiags(np.insert(c[nx:],0,0),diags=1,m=nx,n=nx)
-            A_sparse += sparse.spdiags(np.append(c[nx:],0),diags=-1,m=nx,n=nx)
-
-            if self._compute_A:
-                A = A_sparse.toarray()
-            else:
-                eigenvalues, modes = sparse.linalg.eigs(A_sparse, k=nx-2)
+            eigenvalues, modes, A = self._compute_symtridiagonal(X, Y)
 
         elif manifold in [
             "BC",
             "BCTB",
-            "BCCB", "BCCBskewsymmetric", "BCCBsymmetric", "BCCBunitary"
+            "BCCB",
+            "BCCBunitary",
+            "BCCBsymmetric",
+            "BCCBskewsymmetric",
         ]:
-            self._check_compute_A(manifold)
+            self._check_compute_A()
             # Specify the shape of the blocks in the output matrix A.
             if manifold_opt is None:
                 raise ValueError("manifold_opt must be specified.")
@@ -315,82 +478,12 @@ class PiDMDOperator(DMDOperator):
             block_shape = np.array(manifold_opt)
 
             if manifold.startswith("BCCB"):
-                def fft_block2d(X):
-                    """
-                    Helper method that, given a 2D numpy array X, reshapes the
-                    columns of X into arrays of shape block_shape, computes the
-                    2D discrete Fourier Transform, and returns the resulting
-                    FFT matrix restored to the original X shape and scaled
-                    according to the length of the columns of X.
-                    """
-                    m, n = X.shape
-                    Y = X.reshape(*block_shape, n, order="F")
-                    Y_fft2 = fft2(Y, axes=(0, 1))
-                    return Y_fft2.reshape(m, n, order="F") / np.sqrt(m)
-
-                fX = fft_block2d(X.conj())
-                fY = fft_block2d(Y.conj())
-                d = np.zeros(nx, dtype="complex")
-
-                if manifold == "BCCB":
-                    for j in range(nx):
-                        d[j] = np.dot(fX[j,:], fY[j,:].conj()).conj()
-                        d[j] /= np.linalg.norm(fX[j, :].conj(), 2)**2
-                else:
-                    for j in range(nx):
-                        dp = np.linalg.lstsq(
-                            fX[j,:,None], fY[j,:,None], rcond=None)[0][0][0]
-                        if manifold == "BCCBskewsymmetric":
-                            d[j] = 1j * dp.imag
-                        elif manifold == "BCCBsymmetric":
-                            d[j] = dp.real
-                        else: # BCCBunitary
-                            d[j] = np.exp(1j * np.angle(dp))
-
-                # Remove the least important eigenvalues.
-                r = compute_rank(X, self._svd_rank)
-                res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
-                                np.linalg.norm(fX.conj().T, 2, axis=0).T)
-                ind_exclude = np.argpartition(res, nx-r)[:nx-r]
-                d[ind_exclude] = 0
-                fI = fft_block2d(np.eye(nx))
-                A = fft_block2d(np.multiply(d.conj(), fI.conj().T).T)
-
+                bccb_opt = manifold.removeprefix("BCCB")
+                A = self._compute_BCCB(X, Y, block_shape, bccb_opt)
+            elif manifold == "BC":
+                A = self._compute_BC(X, Y, block_shape)
             else:
-                def fft_block(X):
-                    """
-                    Helper method that, given a 2D numpy array X, reshapes the
-                    columns of X into arrays of shape block_shape, computes the
-                    1D discrete Fourier Transform, and returns the resulting
-                    FFT matrix restored to the original X shape and scaled
-                    according to the number of columns per block.
-                    """
-                    m, n = X.shape
-                    Y = X.reshape(*block_shape, n, order="F")
-                    Y_fft = fft(Y, axis=1)
-                    return Y_fft.reshape(m,n,order="F")/np.sqrt(block_shape[1])
-
-                fX = fft_block(X)
-                fY = fft_block(Y)
-                d = []
-
-                for j in range(block_shape[1]):
-                    ls = (j * block_shape[0]) + np.arange(block_shape[0])
-                    if manifold == "BC":
-                        sol = np.linalg.lstsq(
-                            fX[ls, :].T, fY[ls, :].T, rcond=None)[0].T
-                    else: # BCTB
-                        sol = self._compute_procrustes(
-                            fX[ls,:],
-                            fY[ls,:],
-                            manifold="diagonal",
-                            manifold_opt=2
-                        )[-1]
-                    d.append(sol)
-
-                bd = block_diag(*d)
-                fI = fft_block(np.eye(nx))
-                A = fft_block(bd.dot(fI).conj()).conj()
+                A = self._compute_BC(X, Y, block_shape, tridiagonal_blocks=True)
         else:
             raise ValueError("The selected manifold is not implemented.")
 

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -185,8 +185,8 @@ class PiDMDOperator(DMDOperator):
                     atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
             atilde += -atilde.conj().T - 1j * np.diag(np.diag(atilde.imag))
         else: # symmetric
+            atilde = np.diag(np.diagonal(C).real / s)
             for i in range(r):
-                atilde[i, i] = C[i, i].real / s[i]
                 for j in range(i + 1, r):
                     atilde[i, j] = s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
                     atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -178,8 +178,8 @@ class PiDMDOperator(DMDOperator):
         r = compute_rank(X, self._svd_rank)
 
         if skewsymmetric:
+            atilde = 1j * np.diag(np.diagonal(C).imag / s)
             for i in range(r):
-                atilde[i, i] = 1j * (C[i, i].imag / s[i])
                 for j in range(i + 1, r):
                     atilde[i, j] = -s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
                     atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -7,9 +7,9 @@ Steven L. Brunton. Physics-informed dynamic mode decomposition (pidmd). 2021.
 arXiv:2112.04307.
 """
 import numpy as np
+from numpy.fft import fft, ifft, fft2
 from scipy import sparse
 from scipy.linalg import block_diag, rq
-from numpy.fft import fft, ifft, fft2
 
 from .dmd import DMD
 from .dmdoperator import DMDOperator

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -176,7 +176,6 @@ class PiDMDOperator(DMDOperator):
         U, s, V = compute_svd(X, -1)
         C = np.linalg.multi_dot([U.conj().T, Y, V])
         r = compute_rank(X, self._svd_rank)
-        atilde = np.zeros((r, r), dtype="complex")
 
         if skewsymmetric:
             for i in range(r):

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -396,13 +396,13 @@ class PiDMDOperator(DMDOperator):
         for j in range(block_shape[1]):
             ls = (j * block_shape[0]) + np.arange(block_shape[0])
             if tridiagonal_blocks:
-                sol = self._compute_diagonal(fX[ls], fY[ls], 2)
+                d.append(self._compute_diagonal(fX[ls], fY[ls], 2)[-1])
             else:
-                sol = np.linalg.lstsq(fX[ls].T, fY[ls].T, rcond=None)[0].T
-            d.append(sol)
+                d.append(np.linalg.lstsq(fX[ls].T, fY[ls].T, rcond=None)[0].T)
 
+        BD = block_diag(*d)
         fI = fft_block(np.eye(nx))
-        A = fft_block(block_diag(*d).dot(fI).conj()).conj()
+        A = fft_block(BD.dot(fI).conj()).conj()
 
         return A
 

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -145,10 +145,10 @@ class PiDMDOperator(DMDOperator):
 
         # Solve min||Cx-b|| along each row.
         nxs = np.arange(nx)
-        l1s = (nxs - ind_mat[:, 0] + 1).clip(min=0)
-        l2s = (nxs + ind_mat[:, 1]).clip(max=nx)
+        l1s = (nxs - ind_mat[:, 0] + 1).clip(min=0).astype(int)
+        l2s = (nxs + ind_mat[:, 1]).clip(max=nx).astype(int)
         for j in range(nx):
-                l1, l2 = l1s[j], l2s[j]
+            l1, l2 = l1s[j], l2s[j]
             C = X[l1:l2].T
             b = Y[j].T
             I.append(j * np.ones(l2 - l1))

--- a/pydmd/pidmd.py
+++ b/pydmd/pidmd.py
@@ -144,9 +144,11 @@ class PiDMDOperator(DMDOperator):
         R = []
 
         # Solve min||Cx-b|| along each row.
+        nxs = np.arange(nx)
+        l1s = (nxs - ind_mat[:, 0] + 1).clip(min=0)
+        l2s = (nxs + ind_mat[:, 1]).clip(max=nx)
         for j in range(nx):
-            l1 = int(max(j-(ind_mat[j,0]-1), 0))
-            l2 = int(min(j+(ind_mat[j,1]-1), nx-1) + 1)
+                l1, l2 = l1s[j], l2s[j]
             C = X[l1:l2].T
             b = Y[j].T
             I.append(j * np.ones(l2 - l1))

--- a/pydmd/pidmd_utils.py
+++ b/pydmd/pidmd_utils.py
@@ -1,0 +1,327 @@
+"""
+PiDMD utilities module.
+
+References:
+- Peter J. Baddoo, Benjamin Herrmann, Beverley J. McKeon, J. Nathan Kutz, and
+Steven L. Brunton. Physics-informed dynamic mode decomposition (pidmd). 2021.
+arXiv:2112.04307.
+"""
+import numpy as np
+from numpy.fft import fft, ifft, fft2
+from scipy import sparse
+from scipy.linalg import block_diag, rq
+
+from .utils import compute_svd
+from .rdmd import compute_rank
+
+def compute_unitary(X, Y, svd_rank):
+    """
+    Given the data matrices X and Y and the rank truncation svd_rank, solves
+    for the best-fit unitary operator A that solves the relationship Y = AX.
+    Returns a dictionary containing the corresponding reduced operator atilde.
+    """
+    Ux = compute_svd(X, svd_rank)[0]
+    Yproj = Ux.conj().T.dot(Y)
+    Xproj = Ux.conj().T.dot(X)
+    Uyx, _, Vyx = compute_svd(Yproj.dot(Xproj.conj().T), -1)
+    atilde = Uyx.dot(Vyx.conj().T)
+    return {"atilde": atilde}
+
+def compute_uppertriangular(X, Y):
+    """
+    Given the data matrices X and Y, solves for the best-fit
+    uppertriangular matrix A that solves the relationship Y = AX.
+    Returns a dictionary containing A.
+    """
+    R, Q = rq(X, mode="economic")
+    Ut = np.triu(Y.dot(Q.conj().T))
+    A = np.linalg.lstsq(R.T, Ut.T, rcond=None)[0].T
+    return {"A": A}
+
+def compute_diagonal(X, Y, svd_rank, manifold_opt, compute_A):
+    """
+    Given the data matrices X and Y and the rank truncation svd_rank, solves
+    for the best-fit matrix A that solves the relationship Y = AX and has
+    diagonal entries specified by manifold_opt. Only the eigenvalues and
+    eigenvectors of A are computed if the compute_A flag is not True.
+    Returns a dictionary of computed values.
+    """
+    # Specify the index matrix for the diagonals of A.
+    nx = len(X)
+    if manifold_opt is None:
+        ind_mat = np.ones((nx, 2), dtype=int)
+    elif isinstance(manifold_opt, int) and manifold_opt > 0:
+        ind_mat = manifold_opt * np.ones((nx, 2), dtype=int)
+    elif (isinstance(manifold_opt, tuple)
+            and len(manifold_opt) == 2
+            and np.all(np.array(manifold_opt) > 0)):
+        ind_mat = np.ones((nx, 2))
+        ind_mat[:, 0] *= manifold_opt[0]
+        ind_mat[:, 1] *= manifold_opt[1]
+    elif (isinstance(manifold_opt, np.ndarray)
+            and manifold_opt.shape == (nx, 2)
+            and np.all(manifold_opt > 0)):
+        ind_mat = manifold_opt
+    else:
+        raise ValueError("manifold_opt is not in an allowable format.")
+
+    # Keep track of info for building A as a sparse coordinate matrix.
+    I = []
+    J = []
+    R = []
+
+    # Solve min||Cx-b|| along each row.
+    nxs = np.arange(nx)
+    l1s = (nxs - ind_mat[:, 0] + 1).clip(min=0).astype(int)
+    l2s = (nxs + ind_mat[:, 1]).clip(max=nx).astype(int)
+    for j in range(nx):
+        l1, l2 = l1s[j], l2s[j]
+        C = X[l1:l2].T
+        b = Y[j].T
+        I.append(j * np.ones(l2 - l1))
+        J.append(np.arange(l1, l2))
+        R.append(np.linalg.lstsq(C, b, rcond=None)[0].T)
+
+    # Build A as a sparse matrix.
+    A_sparse = sparse.coo_array(
+        (np.hstack(R), (np.hstack(I), np.hstack(J))), shape=(nx,nx))
+    if compute_A:
+        return {"A": A_sparse.toarray()}
+    r = compute_rank(X, svd_rank)
+    eigenvalues, modes = sparse.linalg.eigs(A_sparse, k=r)
+    return {"eigenvalues": eigenvalues, "modes": modes}
+
+def compute_symmetric(X, Y, svd_rank, skew_symmetric=False):
+    """
+    Given the data matrices X and Y and the rank truncation svd_rank, solves
+    for the best-fit symmetric (or skew-symmetric) operator A that solves the
+    relationship Y = AX. Returns a dictionary containing the corresponding
+    reduced operator atilde.
+    """
+    U, s, V = compute_svd(X, -1)
+    C = np.linalg.multi_dot([U.conj().T, Y, V])
+    r = compute_rank(X, svd_rank)
+    if skew_symmetric:
+        atilde = 1j * np.diag(np.diagonal(C).imag / s)
+        for i in range(r):
+            for j in range(i + 1, r):
+                atilde[i, j] = -s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
+                atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
+        atilde += -atilde.conj().T - 1j * np.diag(np.diag(atilde.imag))
+    else: # symmetric
+        atilde = np.diag(np.diagonal(C).real / s)
+        for i in range(r):
+            for j in range(i + 1, r):
+                atilde[i, j] = s[i] * np.conj(C[j,i]) + s[j] * C[i,j]
+                atilde[i, j] /= (s[i] ** 2 + s[j] ** 2)
+        atilde += atilde.conj().T - np.diag(np.diag(atilde.real))
+    return {"atilde": atilde}
+
+def compute_toeplitz(X, Y, flipped=False):
+    """
+    Given the data matrices X and Y, solves for the best-fit toeplitz operator
+    A (or hankel operator if flipped = True) that solves the relationship
+    Y = AX. Returns a dictionary containing A.
+    """
+    nx, nt = X.shape
+
+    if flipped: # hankel
+        J = np.fliplr(np.eye(nx))
+    else: # toeplitz
+        J = np.eye(nx)
+
+    # Define left and right matrices.
+    Am = fft(np.hstack([np.eye(nx), np.zeros((nx, nx))]).T, axis=0)
+    Am = Am.conj().T / np.sqrt(2 * nx)
+    B = fft(np.hstack([J.dot(X).conj().T, np.zeros((nt, nx))]).T, axis=0)
+    B = B.conj().T / np.sqrt(2 * nx)
+
+    # Compute AA* and B*B (fast computation of AA*).
+    AAt = ifft(fft(np.vstack([
+        np.hstack([np.eye(nx), np.zeros((nx, nx))]),
+        np.zeros((nx, 2 * nx))
+    ]), axis=0).T, axis=0).T
+
+    # Solve linear system y = dL.
+    y = np.diag(np.linalg.multi_dot([Am.conj().T, Y.conj(), B])).conj().T
+    L = np.multiply(AAt, B.conj().T.dot(B).T).conj().T
+    eigenvalues = np.linalg.lstsq(L[:-1, :-1].T, y[:-1], rcond=None)[0]
+    eigenvalues = np.append(eigenvalues, 0)
+
+    # Convert eigenvalues into circulant matrix.
+    new_A = ifft(fft(np.diag(eigenvalues), axis=0).T, axis=0).T
+
+    # Extract toeplitz matrix from the circulant matrix.
+    A = new_A[:nx, :nx].dot(J)
+
+    return {"A": A}
+
+def compute_circulant(X, Y, circulant_opt, svd_rank, compute_A):
+    """
+    Given the data matrices X and Y and the rank truncation svd_rank, solves
+    for the best-fit circulant matrix A that solves the relationship Y = AX and
+    satisfies any additional conditions set by circulant_opt. Only the
+    eigenvalues and eigenvectors of A are computed if the compute_A
+    flag is not True. Returns a dictionary of computed values.
+    """
+    nx = len(X)
+    fX = fft(X, axis=0)
+    fY = fft(Y.conj(), axis=0)
+    fX_norm = np.linalg.norm(fX, axis=1)
+    eigenvalues = np.divide(np.diag(fX.dot(fY.conj().T)), fX_norm ** 2)
+
+    if circulant_opt == "unitary":
+        eigenvalues = np.exp(1j * np.angle(eigenvalues))
+    elif circulant_opt == "symmetric":
+        eigenvalues = eigenvalues.real
+    elif circulant_opt == "skewsymmetric":
+        eigenvalues = 1j * eigenvalues.imag
+
+    # Remove the least important eigenvalues.
+    r = compute_rank(X, svd_rank)
+    res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
+                    np.linalg.norm(fX.conj().T, 2, axis=0).T)
+    ind_exclude = np.argpartition(res, nx-r)[:nx-r]
+    eigenvalues[ind_exclude] = 0
+
+    if compute_A:
+        A = fft(np.multiply(eigenvalues, ifft(np.eye(nx), axis=0).T).T, axis=0)
+        return {"A": A}
+
+    eigenvalues = np.delete(eigenvalues, ind_exclude)
+    modes = np.delete(fft(np.eye(nx), axis=0), ind_exclude, axis=1)
+    return {"eigenvalues": eigenvalues, "modes": modes}
+
+def compute_symtridiagonal(X, Y, svd_rank, compute_A):
+    """
+    Given the data matrices X and Y and the rank truncation svd_rank, solves
+    for the best-fit symmetric tridiagonal matrix A that solves Y = AX.
+    Only the eigenvalues and eigenvectors of A are computed if the compute_A
+    flag is not True. Returns a dictionary of computed values.
+    """
+    # Form the leading block.
+    nx = len(X)
+    T1e = np.linalg.norm(X, axis=1) ** 2
+    T1 = sparse.diags(T1e)
+
+    # Form the second and third blocks.
+    T2e = np.diag(X[1:].dot(X[:-1].T))
+    T2 = sparse.spdiags([T2e, T2e], diags=[-1, 0], m=nx, n=nx-1)
+
+    # Form the final block.
+    T3e = np.insert(np.diag(X[2:].dot(X[:-2].T)), 0, 0)
+    T3_offdiag = sparse.spdiags(T3e, diags=1, m=nx-1, n=nx-1)
+    T3 = sparse.spdiags(T1e[:-1] + T1e[1:], diags=0, m=nx-1, n=nx-1) \
+        + T3_offdiag + T3_offdiag.conj().T
+
+    # Form the symmetric block-tridiagonal matrix T = [T1  T2; T2* T3].
+    T = sparse.vstack([sparse.hstack([T1, T2]),
+                       sparse.hstack([T2.conj().T, T3])])
+
+    # Solve for c in the system Tc = d.
+    d = np.concatenate(
+        (np.diag(X.dot(Y.T)),
+         np.diag(X[:-1].dot(Y[1:].T)) + np.diag(X[1:].dot(Y[:-1].T))),
+         axis=None
+    )
+    c = sparse.linalg.lsqr(T.real, d.real)[0]
+
+    # Form the solution matrix A.
+    A_sparse = sparse.diags(c[:nx]) \
+        + sparse.spdiags(np.insert(c[nx:], 0, 0), diags=1, m=nx, n=nx) \
+        + sparse.spdiags(np.append(c[nx:], 0), diags=-1, m=nx, n=nx)
+
+    if compute_A:
+        return {"A": A_sparse.toarray()}
+
+    r = compute_rank(X, svd_rank)
+    eigenvalues, modes = sparse.linalg.eigs(A_sparse, k=r)
+    return {"eigenvalues": eigenvalues, "modes": modes}
+
+def compute_BCCB(X, Y, block_shape, bccb_opt, svd_rank):
+    """
+    Given the data matrices X and Y and the rank truncation svd_rank, solves
+    for the best-fit BCCB (block circulant with circulant blocks) matrix A that
+    solves the relationship Y = AX. The blocks of A will have the shape
+    block_shape and A will have the additional matrix property given by
+    bccb_opt. Returns a dictionary containing A.
+    """
+    def fft_block2d(X):
+        """
+        Helper method that, given a 2D numpy array X, reshapes the
+        columns of X into arrays of shape block_shape, computes the
+        2D discrete Fourier Transform, and returns the resulting
+        FFT matrix restored to the original X shape and scaled
+        according to the length of the columns of X.
+        """
+        m, n = X.shape
+        Y = X.reshape(*block_shape, n, order="F")
+        Y_fft2 = fft2(Y, axes=(0, 1))
+        return Y_fft2.reshape(m, n, order="F") / np.sqrt(m)
+
+    nx = len(X)
+    fX = fft_block2d(X.conj())
+    fY = fft_block2d(Y.conj())
+    d = np.zeros(nx, dtype="complex")
+
+    if not bccb_opt:
+        for j in range(nx):
+            d[j] = np.dot(fX[j], fY[j].conj()).conj()
+            d[j] /= np.linalg.norm(fX[j].conj(), 2)**2
+    else:
+        for j in range(nx):
+            dp = np.linalg.lstsq(
+                fX[j,:,None], fY[j,:,None], rcond=None)[0][0][0]
+            if bccb_opt == "unitary":
+                d[j] = np.exp(1j * np.angle(dp))
+            elif bccb_opt == "symmetric":
+                d[j] = dp.real
+            else: # skewsymmetric
+                d[j] = 1j * dp.imag
+
+    # Remove the least important eigenvalues.
+    r = compute_rank(X, svd_rank)
+    res = np.divide(np.diag(np.abs(fX.dot(fY.conj().T))),
+                    np.linalg.norm(fX.conj().T, 2, axis=0).T)
+    d[np.argpartition(res, nx-r)[:nx-r]] = 0
+    A = fft_block2d(np.multiply(d.conj(), fft_block2d(np.eye(nx)).conj().T).T)
+    return {"A": A}
+
+def compute_BC(X, Y, block_shape, tridiagonal_blocks=False):
+    """
+    Given the data matrices X and Y, solves for the best-fit block circulant
+    matrix A that solves the relationship Y = AX. The blocks of A will have the
+    shape block_shape and will be tridiagonal if tridiagonal_blocks is True.
+    Returns a dictionary containing A.
+    """
+    def fft_block(X):
+        """
+        Helper method that, given a 2D numpy array X, reshapes the
+        columns of X into arrays of shape block_shape, computes the
+        1D discrete Fourier Transform, and returns the resulting
+        FFT matrix restored to the original X shape and scaled
+        according to the number of columns per block.
+        """
+        m, n = X.shape
+        Y = X.reshape(*block_shape, n, order="F")
+        Y_fft = fft(Y, axis=1)
+        return Y_fft.reshape(m, n, order="F") / np.sqrt(block_shape[1])
+
+    nx = len(X)
+    fX = fft_block(X)
+    fY = fft_block(Y)
+    d = []
+
+    for j in range(block_shape[1]):
+        ls = (j * block_shape[0]) + np.arange(block_shape[0])
+        if tridiagonal_blocks:
+            d.append(compute_diagonal(fX[ls], fY[ls], svd_rank=-1,
+                                      manifold_opt=2, compute_A=True)["A"])
+        else:
+            d.append(np.linalg.lstsq(fX[ls].T, fY[ls].T, rcond=None)[0].T)
+
+    # Update self._A to be the full block circulant matrix.
+    BD = block_diag(*d)
+    fI = fft_block(np.eye(nx))
+    A = fft_block(BD.dot(fI).conj()).conj()
+    return {"A": A}

--- a/pydmd/pidmd_utils.py
+++ b/pydmd/pidmd_utils.py
@@ -83,7 +83,7 @@ def compute_diagonal(X, Y, svd_rank, manifold_opt, compute_A):
         R.append(np.linalg.lstsq(C, b, rcond=None)[0].T)
 
     # Build A as a sparse matrix.
-    A_sparse = sparse.coo_array(
+    A_sparse = sparse.coo_matrix(
         (np.hstack(R), (np.hstack(I), np.hstack(J))), shape=(nx,nx))
     if compute_A:
         return {"A": A_sparse.toarray()}

--- a/pydmd/rdmd.py
+++ b/pydmd/rdmd.py
@@ -45,7 +45,7 @@ def compute_rank(X, svd_rank=0):
     elif svd_rank >= 1 and isinstance(svd_rank, int):
         rank = min(svd_rank, U.shape[1])
     else:
-        rank = X.shape[1]
+        rank = min(X.shape)
 
     return rank
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION = meta['__version__']
 KEYWORDS = 'dynamic-mode-decomposition dmd mrdmd fbdmd cdmd'
 
 REQUIRED = [
-    'future', 'numpy', 'scipy>=1.8',	'matplotlib'
+    'future', 'numpy', 'scipy',	'matplotlib'
 ]
 
 EXTRAS = {

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION = meta['__version__']
 KEYWORDS = 'dynamic-mode-decomposition dmd mrdmd fbdmd cdmd'
 
 REQUIRED = [
-    'future', 'numpy', 'scipy',	'matplotlib'
+    'future', 'numpy', 'scipy>=1.8',	'matplotlib'
 ]
 
 EXTRAS = {

--- a/tests/test_pidmd.py
+++ b/tests/test_pidmd.py
@@ -31,14 +31,14 @@ def assert_all_zero(A):
     Helper method that, given a matrix A, tests that A is
     approximately a matrix of only zero entries.
     """
-    assert_allclose(np.linalg.norm(A), 0, atol=1e-15)
+    assert_allclose(np.linalg.norm(A), 0, atol=1e-14)
 
 def assert_circulant(A):
     """
     Helper method that, given a matrix A, tests that A is a circulant matrix.
     """
     for i in range(1, len(A)):
-        assert_allclose(np.roll(A[i, :], -i), A[0, :], atol=1e-15)
+        assert_allclose(np.roll(A[i, :], -i), A[0, :], atol=1e-14)
 
 def assert_block_circulant(A):
     """
@@ -49,7 +49,7 @@ def assert_block_circulant(A):
     for i in range(1, block_n):
         block_row_i = A[i*block_n:(i+1)*block_n, :]
         rolled_block_row_i = np.roll(block_row_i, -i*block_n, axis=1)
-        assert_allclose(rolled_block_row_i, A[:block_n, :], atol=1e-15)
+        assert_allclose(rolled_block_row_i, A[:block_n, :], atol=1e-14)
 
 def test_invalid_manifold():
     # Test that an error is thrown if an invalid manifold is given.
@@ -59,7 +59,7 @@ def test_invalid_manifold():
 def test_unitary():
     pidmd = PiDMD("unitary", compute_A=True).fit(X)
     # Ensure that the A matrix is unitary and accurate.
-    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-15)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-14)
     assert_accurate(pidmd.A)
 
 def test_uppertriangular():
@@ -110,7 +110,7 @@ def test_symmetric():
 def test_skewsymmetric():
     pidmd = PiDMD("skewsymmetric", compute_A=True).fit(X)
     # Ensure that the A matrix is skewsymmetric and accurate.
-    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-15)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-14)
     assert_accurate(pidmd.A)
 
 def test_toeplitz():
@@ -145,7 +145,7 @@ def test_circulant():
     pidmd = PiDMD("circulant_unitary", compute_A=True).fit(X)
     assert_circulant(pidmd.A)
     assert_accurate(pidmd.A)
-    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-15)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-14)
 
     # Test circulant_symmetric case.
     pidmd = PiDMD("circulant_symmetric", compute_A=True).fit(X)
@@ -157,7 +157,7 @@ def test_circulant():
     pidmd = PiDMD("circulant_skewsymmetric", compute_A=True).fit(X)
     assert_circulant(pidmd.A)
     assert_accurate(pidmd.A)
-    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-15)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-14)
 
 def test_symmetric_tridiagonal():
     pidmd = PiDMD("symmetric_tridiagonal", compute_A=True).fit(X)
@@ -206,7 +206,7 @@ def test_BC():
         for j in range(5):
             block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
             assert_circulant(block)
-    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-15)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-14)
 
     # BCCB and symmetric
     pidmd = PiDMD("BCCBsymmetric", manifold_opt=(5,5), compute_A=True).fit(X)
@@ -226,4 +226,4 @@ def test_BC():
         for j in range(5):
             block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
             assert_circulant(block)
-    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-15)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-14)

--- a/tests/test_pidmd.py
+++ b/tests/test_pidmd.py
@@ -31,14 +31,14 @@ def assert_all_zero(A):
     Helper method that, given a matrix A, tests that A is
     approximately a matrix of only zero entries.
     """
-    assert_allclose(np.linalg.norm(A), 0, atol=5*1e-15)
+    assert_allclose(np.linalg.norm(A), 0, atol=1e-15)
 
 def assert_circulant(A):
     """
     Helper method that, given a matrix A, tests that A is a circulant matrix.
     """
     for i in range(1, len(A)):
-        assert_allclose(np.roll(A[i, :], -i), A[0, :], atol=5*1e-15)
+        assert_allclose(np.roll(A[i, :], -i), A[0, :], atol=1e-15)
 
 def assert_block_circulant(A):
     """
@@ -49,7 +49,7 @@ def assert_block_circulant(A):
     for i in range(1, block_n):
         block_row_i = A[i*block_n:(i+1)*block_n, :]
         rolled_block_row_i = np.roll(block_row_i, -i*block_n, axis=1)
-        assert_allclose(rolled_block_row_i, A[:block_n, :], atol=5*1e-15)
+        assert_allclose(rolled_block_row_i, A[:block_n, :], atol=1e-15)
 
 def test_invalid_manifold():
     # Test that an error is thrown if an invalid manifold is given.
@@ -59,7 +59,7 @@ def test_invalid_manifold():
 def test_unitary():
     pidmd = PiDMD("unitary", compute_A=True).fit(X)
     # Ensure that the A matrix is unitary and accurate.
-    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=5*1e-15)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-15)
     assert_accurate(pidmd.A)
 
 def test_uppertriangular():
@@ -110,7 +110,7 @@ def test_symmetric():
 def test_skewsymmetric():
     pidmd = PiDMD("skewsymmetric", compute_A=True).fit(X)
     # Ensure that the A matrix is skewsymmetric and accurate.
-    assert_allclose(pidmd.A, -pidmd.A.T, atol=5*1e-15)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-15)
     assert_accurate(pidmd.A)
 
 def test_toeplitz():
@@ -145,7 +145,7 @@ def test_circulant():
     pidmd = PiDMD("circulant_unitary", compute_A=True).fit(X)
     assert_circulant(pidmd.A)
     assert_accurate(pidmd.A)
-    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=5*1e-15)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-15)
 
     # Test circulant_symmetric case.
     pidmd = PiDMD("circulant_symmetric", compute_A=True).fit(X)
@@ -157,7 +157,7 @@ def test_circulant():
     pidmd = PiDMD("circulant_skewsymmetric", compute_A=True).fit(X)
     assert_circulant(pidmd.A)
     assert_accurate(pidmd.A)
-    assert_allclose(pidmd.A, -pidmd.A.T, atol=5*1e-15)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-15)
 
 def test_symmetric_tridiagonal():
     pidmd = PiDMD("symmetric_tridiagonal", compute_A=True).fit(X)
@@ -206,7 +206,7 @@ def test_BC():
         for j in range(5):
             block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
             assert_circulant(block)
-    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=5*1e-15)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=1e-15)
 
     # BCCB and symmetric
     pidmd = PiDMD("BCCBsymmetric", manifold_opt=(5,5), compute_A=True).fit(X)
@@ -226,4 +226,4 @@ def test_BC():
         for j in range(5):
             block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
             assert_circulant(block)
-    assert_allclose(pidmd.A, -pidmd.A.T, atol=5*1e-15)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=1e-15)

--- a/tests/test_pidmd.py
+++ b/tests/test_pidmd.py
@@ -1,0 +1,229 @@
+import numpy as np
+from pytest import raises
+from numpy.testing import assert_allclose
+from pydmd.pidmd import PiDMD
+
+def error(true, comp):
+    """Helper function that computes and returns relative error."""
+    return np.linalg.norm(comp - true) / np.linalg.norm(true)
+
+# Use random matrix as dummy data.
+rng = np.random.default_rng(seed=42)
+X = rng.standard_normal((25, 1000))
+X1 = X[:, :-1]
+X2 = X[:, 1:]
+
+# Compute A via pseudoinverse as benchmark.
+A_dmd = X2.dot(np.linalg.pinv(X1))
+dmd_error = error(X2, A_dmd.dot(X1))
+error_tol = 0.45 * dmd_error
+
+def assert_accurate(A):
+    """
+    Helper method that, given a computed A matrix, tests that A is an
+    accurate operator relative to that obtained via standard DMD.
+    """
+    computed_error = error(X2, A.dot(X1))
+    assert_allclose(computed_error, dmd_error, atol=error_tol)
+
+def assert_all_zero(A):
+    """
+    Helper method that, given a matrix A, tests that A is
+    approximately a matrix of only zero entries.
+    """
+    assert_allclose(np.linalg.norm(A), 0, atol=5*1e-15)
+
+def assert_circulant(A):
+    """
+    Helper method that, given a matrix A, tests that A is a circulant matrix.
+    """
+    for i in range(1, len(A)):
+        assert_allclose(np.roll(A[i, :], -i), A[0, :], atol=5*1e-15)
+
+def assert_block_circulant(A):
+    """
+    Helper method that, given a matrix A, tests that A is block circulant.
+    Assumes A is a square matrix composed of equally-sized square blocks.
+    """
+    block_n = int(np.sqrt(len(A)))
+    for i in range(1, block_n):
+        block_row_i = A[i*block_n:(i+1)*block_n, :]
+        rolled_block_row_i = np.roll(block_row_i, -i*block_n, axis=1)
+        assert_allclose(rolled_block_row_i, A[:block_n, :], atol=5*1e-15)
+
+def test_invalid_manifold():
+    # Test that an error is thrown if an invalid manifold is given.
+    with raises(ValueError):
+        PiDMD("some_manifold").fit(X)
+
+def test_unitary():
+    pidmd = PiDMD("unitary", compute_A=True).fit(X)
+    # Ensure that the A matrix is unitary and accurate.
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=5*1e-15)
+    assert_accurate(pidmd.A)
+
+def test_uppertriangular():
+    # Throw error if model is fitted without computing A.
+    with raises(ValueError):
+        pidmd = PiDMD("uppertriangular").fit(X)
+    pidmd = PiDMD("uppertriangular", compute_A=True).fit(X)
+    # Ensure that the A matrix is uppertriangular and accurate.
+    assert_all_zero(np.tril(pidmd.A, k=-1))
+    assert_accurate(pidmd.A)
+
+def test_lowertriangular():
+    # Throw error if model is fitted without computing A.
+    with raises(ValueError):
+        pidmd = PiDMD("lowertriangular").fit(X)
+    pidmd = PiDMD("lowertriangular", compute_A=True).fit(X)
+    # Ensure that the A matrix is lowertriangular and accurate.
+    assert_all_zero(np.triu(pidmd.A, k=1))
+    assert_accurate(pidmd.A)
+
+def test_diagonal():
+    # Throw error if manifold_opt is formatted incorrectly.
+    with raises(ValueError):
+        pidmd = PiDMD("diagonal", manifold_opt=-1, compute_A=True).fit(X)
+
+    # Test diagonal model with integer manifold_opt.
+    pidmd = PiDMD("diagonal", manifold_opt=1, compute_A=True).fit(X)
+    assert_all_zero(pidmd.A - np.diag(np.diag(pidmd.A)))
+    assert_accurate(pidmd.A)
+
+    # Test tridiagonal model with tuple manifold_opt.
+    pidmd = PiDMD("diagonal", manifold_opt=(2,2), compute_A=True).fit(X)
+    assert_all_zero(np.triu(pidmd.A, k=2) + np.tril(pidmd.A, k=-2))
+    assert_accurate(pidmd.A)
+
+    # Test model with custom (2, nx) manifold_opt.
+    custom_opt = np.hstack((np.ones((25,1)), 4*np.ones((25,1))))
+    pidmd = PiDMD("diagonal", manifold_opt=custom_opt, compute_A=True).fit(X)
+    assert_all_zero(np.triu(pidmd.A, k=4) + np.tril(pidmd.A, k=-1))
+    assert_accurate(pidmd.A)
+
+def test_symmetric():
+    pidmd = PiDMD("symmetric", compute_A=True).fit(X)
+    # Ensure that the A matrix is symmetric and accurate.
+    assert_allclose(pidmd.A, pidmd.A.T)
+    assert_accurate(pidmd.A)
+
+def test_skewsymmetric():
+    pidmd = PiDMD("skewsymmetric", compute_A=True).fit(X)
+    # Ensure that the A matrix is skewsymmetric and accurate.
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=5*1e-15)
+    assert_accurate(pidmd.A)
+
+def test_toeplitz():
+    # Throw error if model is fitted without computing A.
+    with raises(ValueError):
+        pidmd = PiDMD("toeplitz").fit(X)
+    pidmd = PiDMD("toeplitz", compute_A=True).fit(X)
+    # Ensure that the A matrix is toeplitz and accurate.
+    for k in range(-24, 25):
+        k_diag = np.diag(pidmd.A, k=k)
+        assert_allclose(k_diag, k_diag[0]*np.ones(k_diag.shape))
+    assert_accurate(pidmd.A)
+
+def test_hankel():
+    # Throw error if model is fitted without computing A.
+    with raises(ValueError):
+        pidmd = PiDMD("hankel").fit(X)
+    pidmd = PiDMD("hankel", compute_A=True).fit(X)
+    # Ensure that the A matrix is hankel and accurate.
+    for k in range(-24, 25):
+        k_diag = np.diag(np.fliplr(pidmd.A), k=k)
+        assert_allclose(k_diag, k_diag[0]*np.ones(k_diag.shape))
+    assert_accurate(pidmd.A)
+
+def test_circulant():
+    # Test circulant case.
+    pidmd = PiDMD("circulant", compute_A=True).fit(X)
+    assert_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+
+    # Test circulant_unitary case.
+    pidmd = PiDMD("circulant_unitary", compute_A=True).fit(X)
+    assert_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=5*1e-15)
+
+    # Test circulant_symmetric case.
+    pidmd = PiDMD("circulant_symmetric", compute_A=True).fit(X)
+    assert_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    assert_allclose(pidmd.A, pidmd.A.T)
+
+    # Test circulant_skewsymmetric case.
+    pidmd = PiDMD("circulant_skewsymmetric", compute_A=True).fit(X)
+    assert_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=5*1e-15)
+
+def test_symmetric_tridiagonal():
+    pidmd = PiDMD("symmetric_tridiagonal", compute_A=True).fit(X)
+    # Ensure that the A matrix is symmetric, tridiagonal, and accurate.
+    assert_allclose(pidmd.A, pidmd.A.T)
+    assert_all_zero(np.triu(pidmd.A, k=2) + np.tril(pidmd.A, k=-2))
+    assert_accurate(pidmd.A)
+
+def test_BC():
+    # Throw error if model is fitted without computing A.
+    with raises(ValueError):
+        pidmd = PiDMD("BC", manifold_opt=(5,5)).fit(X)
+
+    # Throw error if model is fitted without providing block size.
+    with raises(ValueError):
+        pidmd = PiDMD("BC", compute_A=True).fit(X)
+
+    # BC (block circulant)
+    pidmd = PiDMD("BC", manifold_opt=(5,5), compute_A=True).fit(X)
+    assert_block_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+
+    # BCTB (block circulant with tridiagonal blocks)
+    pidmd = PiDMD("BCTB", manifold_opt=(5,5), compute_A=True).fit(X)
+    assert_block_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    for i in range(5):
+        for j in range(5):
+            block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
+            assert_all_zero(np.triu(block, k=2) + np.tril(block, k=-2))
+
+    # BCCB (block circulant with circulant blocks)
+    pidmd = PiDMD("BCCB", manifold_opt=(5,5), compute_A=True).fit(X)
+    assert_block_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    for i in range(5):
+        for j in range(5):
+            block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
+            assert_circulant(block)
+
+    # BCCB and unitary
+    pidmd = PiDMD("BCCBunitary", manifold_opt=(5,5), compute_A=True).fit(X)
+    assert_block_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    for i in range(5):
+        for j in range(5):
+            block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
+            assert_circulant(block)
+    assert_allclose(pidmd.A.conj().T.dot(pidmd.A), np.eye(25), atol=5*1e-15)
+
+    # BCCB and symmetric
+    pidmd = PiDMD("BCCBsymmetric", manifold_opt=(5,5), compute_A=True).fit(X)
+    assert_block_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    for i in range(5):
+        for j in range(5):
+            block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
+            assert_circulant(block)
+    assert_allclose(pidmd.A, pidmd.A.T)
+
+    # BCCB and skewsymmetric
+    pidmd = PiDMD("BCCBskewsymmetric",manifold_opt=(5,5),compute_A=True).fit(X)
+    assert_block_circulant(pidmd.A)
+    assert_accurate(pidmd.A)
+    for i in range(5):
+        for j in range(5):
+            block = pidmd.A[i*5:(i+1)*5, j*5:(j+1)*5]
+            assert_circulant(block)
+    assert_allclose(pidmd.A, -pidmd.A.T, atol=5*1e-15)


### PR DESCRIPTION
Hello PyDMD team! 😃 

Here is yet another potential addition to the PyDMD family of modules: [Physics-informed DMD](https://arxiv.org/abs/2112.04307).

In short, Physics-informed DMD (PiDMD) simply replaces the DMD regression scheme

$A = \text{argmin}_{\text{rank}(A)=r} ||Y-AX||_F$

with 

$A = \text{argmin}_{A \in \mathcal{M}} ||Y-AX||_F$

where $\mathcal{M}$ denotes some user-chosen matrix manifold that contains a family of matrices, such as unitary matrices, symmetric matrices, etc. In doing so, one has the option to constrain the structure of the DMD matrix $A$ in the event that the user possesses some knowledge or intuition regarding the physics of their dataset and therefore the structure of the operator $A$. In doing so, one has potential to create DMD models that are more physically accurate as well as robust to measurement noise.

In my implementation of the `PiDMD` module, the module is extended from the `DMD` class since the only difference between the two modules is the execution of the `compute_operator` function. For `PiDMD` in particular, `compute_operator` is overwritten so that it involves solving the specific Procrustes problem that is associated with the inputted matrix manifold. Currently, 19 matrix manifolds may be evaluated by the module, with each manifold having a corresponding test within the `test_pidmd.py` file.

Additionally as a minor edit, I've edited the `compute_rank` function so that in the event that `svd_rank=-1` the rank that is returned is $\text{min}(m,n)$ for a data matrix $X \in \mathbb{R}^{m \times n}$, mostly because this seems to be more reflective of the chosen rank in the event that no truncation is desired.

Thank you so much for your kind and generous support in this endeavor to build upon this already amazing package. And as always, feel free to follow up with me on anything regarding this PR and please let me know if there's anything that I can do to get this PR up to standards. :)

Sincerely,
Sara Ichinaga