### PR TITLE
Ignore `SegTrackv2.zip`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pydmd\.egg-info/
 .idea/*
 
 tutorials/\.ipynb_checkpoints/
+**/SegTrackv2.zip
 
 # Vscode
 .vscode/*

--- a/tutorials/tutorial14/tutorial-14-bop-dmd.ipynb
+++ b/tutorials/tutorial14/tutorial-14-bop-dmd.ipynb
@@ -736,7 +736,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fixes the GitHub action which exports tutorials by making sure `SegTrackv2.zip` is not allowed to enter the staged state.